### PR TITLE
fixing api error with latest stable Docker for Mac k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Make sure that the solr-operator and a zookeeper-operator are running.
 Create an example Solr cloud, with the following configuration.
 
 ```bash
-$ cat example/test-solrcloud.yaml
+$ cat example/test_solrcloud.yaml
 
 apiVersion: solr.bloomberg.com/v1beta1
 kind: SolrCloud
@@ -53,7 +53,7 @@ spec:
 Apply it to your Kubernetes cluster.
 
 ```bash
-$ kubectl apply -f example/test-solrcloud.yaml
+$ kubectl apply -f example/test_solrcloud.yaml
 $ kubectl get solrclouds
 
 NAME      VERSION   DESIREDNODES   NODES   READYNODES   AGE

--- a/config/operators/solr_operator.yaml
+++ b/config/operators/solr_operator.yaml
@@ -236,7 +236,7 @@ subjects:
   name: default
   namespace: default
 ---
-apiVersion: v1beta1
+apiVersion: v1
 kind: Secret
 metadata:
   name: webhook-server-secret

--- a/example/ext_ops.yaml
+++ b/example/ext_ops.yaml
@@ -112,7 +112,7 @@ spec:
             value: "zk-operator"
 
 ---
-apiVersion: v1beta1
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: zookeeper-operator


### PR DESCRIPTION
**Describe your changes**
Docker for Mac stable release uses k8s v1.10.11 (sort of old)

The example setup will error with

```
$ kubectl apply -f example/ext_ops.yaml
deployment.apps/etcd-operator unchanged
customresourcedefinition.apiextensions.k8s.io/zookeeperclusters.zookeeper.pravega.io configured
deployment.apps/zk-operator configured
clusterrole.rbac.authorization.k8s.io/zookeeper-operator unchanged
clusterrolebinding.rbac.authorization.k8s.io/zookeeper-operator-cluster-role-binding unchanged
error: unable to recognize "example/ext_ops.yaml": no matches for kind "ServiceAccount" in version "v1beta1"
```

and

```
$ kubectl apply -f config/operators/solr_operator.yaml
clusterrole.rbac.authorization.k8s.io/manager-role created
clusterrolebinding.rbac.authorization.k8s.io/manager-rolebinding created
deployment.apps/solr-operator created
error: unable to recognize "config/operators/solr_operator.yaml": no matches for kind "Secret" in version "v1beta1"
```

**Testing performed**
Testing on Docker for Mac: Version 2.0.0.3 (31259)
