### PR TITLE
Making java memory configurable

### DIFF
--- a/config/crds/solr_v1beta1_solrcloud.yaml
+++ b/config/crds/solr_v1beta1_solrcloud.yaml
@@ -98,6 +98,8 @@ spec:
                 tag:
                   type: string
               type: object
+            solrJavaMem:
+              type: string
             zookeeperRef:
               description: The information for the Zookeeper this SolrCloud should
                 connect to Can be a zookeeper that is running, or one that is created

--- a/example/test_solrcloud.yaml
+++ b/example/test_solrcloud.yaml
@@ -6,3 +6,4 @@ spec:
   replicas: 4
   solrImage:
     tag: 8.2.0
+  solrJavaMem: "-Xms1g -Xmx3g"

--- a/pkg/apis/solr/v1beta1/solrcloud_types.go
+++ b/pkg/apis/solr/v1beta1/solrcloud_types.go
@@ -18,10 +18,11 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 const (
@@ -31,6 +32,7 @@ const (
 	DefaultSolrRepo     = "library/solr"
 	DefaultSolrVersion  = "7.7.0"
 	DefaultSolrStorage  = "5Gi"
+	DefaultSolrJavaMem  = "-Xms1g -Xmx2g"
 
 	DefaultBusyBoxImageRepo    = "library/busybox"
 	DefaultBusyBoxImageVersion = "1.28.0-glibc"
@@ -82,6 +84,9 @@ type SolrCloudSpec struct {
 
 	// +optional
 	BusyBoxImage *ContainerImage `json:"busyBoxImage,omitempty"`
+
+	// +optional
+	SolrJavaMem string `json:"solrJavaMem,omitempty"`
 }
 
 func (spec *SolrCloudSpec) withDefaults() (changed bool) {
@@ -89,6 +94,11 @@ func (spec *SolrCloudSpec) withDefaults() (changed bool) {
 		changed = true
 		r := DefaultSolrReplicas
 		spec.Replicas = &r
+	}
+
+	if spec.SolrJavaMem == "" {
+		changed = true
+		spec.SolrJavaMem = DefaultSolrJavaMem
 	}
 
 	if spec.ZookeeperRef == nil {

--- a/pkg/controller/util/solr_util.go
+++ b/pkg/controller/util/solr_util.go
@@ -174,7 +174,7 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, ingressBaseDomain string, ho
 							Env: []corev1.EnvVar{
 								{
 									Name:  "SOLR_JAVA_MEM",
-									Value: "-Xms1g -Xmx2g",
+									Value: solrCloud.Spec.SolrJavaMem,
 								},
 								{
 									Name:  "SOLR_HOME",


### PR DESCRIPTION
Signed-off-by: Zane Williamson <zanew@zillow.com>

Describe your changes
Remove hardcoded memory allocation, and give ability to update jvm parameter.

Testing performed
Tested locally with solrcloud 8.2
Tested to verify present hardcoded value works as default