### PR TITLE
Adding Optional imagePullSecret for private Docker repo access, Fix Missing Statefulset params

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,6 @@ spec:
 $ kubectl apply -f examples/test_solrcollections.yaml
 ```
   
-## Solr Images
-
-The solr-operator will work with any of the [official Solr images](https://hub.docker.com/_/solr) currently available.
-
 ## Zookeeper
 =======
 ### Zookeeper Reference
@@ -266,8 +262,28 @@ Versions `6.6` - `7.x` and `8.2` - `master` should have the exporter available.
   
 ## Solr Images
 
+### Official Solr Images
+
 The solr-operator will work with any of the [official Solr images](https://hub.docker.com/_/solr) currently available.
 
+### Build Your Own Private Solr Images
+
+The solr-operator supports private Docker repo access for Solr images you may want to store in a private Docker repo. It is recommended to source your image from the official Solr images. 
+
+Using a private image requires you have a K8s secret preconfigured with appropreiate access to the image. (type: kubernetes.io/dockerconfigjson)
+
+```
+apiVersion: solr.bloomberg.com/v1beta1
+kind: SolrCloud
+metadata:
+  name: example-private-repo-solr-image
+spec:
+  replicas: 3
+  solrImage:
+    repository: myprivate-repo.jfrog.io/solr
+    tag: 8.2.0
+    imagePullSecret: "k8s-docker-registry-secret"
+```
 
 ## Solr Operator
 

--- a/config/crds/solr_v1beta1_solrbackup.yaml
+++ b/config/crds/solr_v1beta1_solrbackup.yaml
@@ -64,6 +64,8 @@ spec:
                     AWSCliImage:
                       description: Image containing the AWS Cli
                       properties:
+                        imagePullSecret:
+                          type: string
                         pullPolicy:
                           type: string
                         repository:
@@ -127,6 +129,8 @@ spec:
                     busyBoxImage:
                       description: BusyBox image for manipulating and moving data
                       properties:
+                        imagePullSecret:
+                          type: string
                         pullPolicy:
                           type: string
                         repository:

--- a/config/crds/solr_v1beta1_solrcloud.yaml
+++ b/config/crds/solr_v1beta1_solrcloud.yaml
@@ -73,6 +73,8 @@ spec:
               type: object
             busyBoxImage:
               properties:
+                imagePullSecret:
+                  type: string
                 pullPolicy:
                   type: string
                 repository:
@@ -91,6 +93,8 @@ spec:
               type: integer
             solrImage:
               properties:
+                imagePullSecret:
+                  type: string
                 pullPolicy:
                   type: string
                 repository:
@@ -137,6 +141,8 @@ spec:
                         image:
                           description: Image of Zookeeper to run
                           properties:
+                            imagePullSecret:
+                              type: string
                             pullPolicy:
                               type: string
                             repository:

--- a/config/crds/solr_v1beta1_solrprometheusexporter.yaml
+++ b/config/crds/solr_v1beta1_solrprometheusexporter.yaml
@@ -51,6 +51,8 @@ spec:
             image:
               description: Image of Solr Prometheus Exporter to run.
               properties:
+                imagePullSecret:
+                  type: string
                 pullPolicy:
                   type: string
                 repository:

--- a/example/test_solrcloud_private_repo.yaml
+++ b/example/test_solrcloud_private_repo.yaml
@@ -1,0 +1,10 @@
+apiVersion: solr.bloomberg.com/v1beta1
+kind: SolrCloud
+metadata:
+  name: example-private-repo-solr-image
+spec:
+  replicas: 3
+  solrImage:
+    repository: myprivate-repo.jfrog.io/solr
+    tag: 8.2.0
+    imagePullSecret: "k8s-docker-registry-secret"

--- a/pkg/apis/solr/v1beta1/solrbackup_types.go
+++ b/pkg/apis/solr/v1beta1/solrbackup_types.go
@@ -18,9 +18,10 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 const (

--- a/pkg/apis/solr/v1beta1/solrcloud_types.go
+++ b/pkg/apis/solr/v1beta1/solrcloud_types.go
@@ -141,6 +141,8 @@ type ContainerImage struct {
 	Tag string `json:"tag,omitempty"`
 	// +optional
 	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
+	// +optional
+	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 }
 
 func (c *ContainerImage) withDefaults(repo string, version string, policy corev1.PullPolicy) (changed bool) {

--- a/pkg/apis/solr/v1beta1/solrprometheusexporter_types.go
+++ b/pkg/apis/solr/v1beta1/solrprometheusexporter_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/controller/solrcloud/solrcloud_controller.go
+++ b/pkg/controller/solrcloud/solrcloud_controller.go
@@ -19,11 +19,12 @@ package solrcloud
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/bloomberg/solr-operator/pkg/controller/util"
 	extv1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
-	"reflect"
-	"strings"
 
 	solr "github.com/bloomberg/solr-operator/pkg/apis/solr/v1beta1"
 	etcd "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"

--- a/pkg/controller/util/backup_util.go
+++ b/pkg/controller/util/backup_util.go
@@ -19,6 +19,8 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"net/url"
+
 	solr "github.com/bloomberg/solr-operator/pkg/apis/solr/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"net/url"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Zane Williamson zanew@zillow.com

*Issue number of the reported bug or feature request: #28

Describe your changes
Add optional ability to use a private Docker repo to store and pull SolrCloud images. Requires a predefined K8s secret to reference that is leveraged for accessing private docker repo.

Testing performed
Deployed changes to local development environment and validated image pulls from private Artifactory Docker repository.

Tested using type: kubernetes.io/dockerconfigjson Secret.

Additional context
With this change you can now publish to a private repo SolrCloud images that may contain additional plugins / Jars that your team may be using to extend SolrCloud.