### PR TITLE
Adding configurable SOLR_OPTS, GC_TUNE, logging

### DIFF
--- a/config/crds/solr_v1beta1_solrcloud.yaml
+++ b/config/crds/solr_v1beta1_solrcloud.yaml
@@ -89,6 +89,10 @@ spec:
               description: The number of solr nodes to run
               format: int32
               type: integer
+            solrGCTune:
+              description: Set GC Tuning configuration through GC_TUNE environment
+                variable
+              type: string
             solrImage:
               properties:
                 pullPolicy:
@@ -99,6 +103,13 @@ spec:
                   type: string
               type: object
             solrJavaMem:
+              type: string
+            solrLogLevel:
+              description: Set the Solr Log level, defaults to INFO
+              type: string
+            solrOpts:
+              description: You can add common system properties to the SOLR_OPTS environment
+                variable SolrOpts is the string interface for these optional settings
               type: string
             zookeeperRef:
               description: The information for the Zookeeper this SolrCloud should

--- a/example/test_solrcloud.yaml
+++ b/example/test_solrcloud.yaml
@@ -7,3 +7,5 @@ spec:
   solrImage:
     tag: 8.2.0
   solrJavaMem: "-Xms1g -Xmx3g"
+  solrOpts: "-Dsolr.autoSoftCommit.maxTime=10000"
+  solrGCTune: "-XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8"

--- a/pkg/apis/solr/v1beta1/solrcloud_types.go
+++ b/pkg/apis/solr/v1beta1/solrcloud_types.go
@@ -112,22 +112,22 @@ func (spec *SolrCloudSpec) withDefaults() (changed bool) {
 		spec.Replicas = &r
 	}
 
-	if spec.SolrJavaMem == "" {
+	if spec.SolrJavaMem == "" && DefaultSolrJavaMem != "" {
 		changed = true
 		spec.SolrJavaMem = DefaultSolrJavaMem
 	}
 
-	if spec.SolrOpts == "" {
+	if spec.SolrOpts == "" && DefaultSolrOpts != "" {
 		changed = true
 		spec.SolrOpts = DefaultSolrOpts
 	}
 
-	if spec.SolrLogLevel == "" {
+	if spec.SolrLogLevel == "" && DefaultSolrLogLevel != "" {
 		changed = true
 		spec.SolrLogLevel = DefaultSolrLogLevel
 	}
 
-	if spec.SolrGCTune == "" {
+	if spec.SolrGCTune == "" && DefaultSolrGCTune != "" {
 		changed = true
 		spec.SolrGCTune = DefaultSolrGCTune
 	}

--- a/pkg/apis/solr/v1beta1/solrcloud_types.go
+++ b/pkg/apis/solr/v1beta1/solrcloud_types.go
@@ -33,6 +33,9 @@ const (
 	DefaultSolrVersion  = "7.7.0"
 	DefaultSolrStorage  = "5Gi"
 	DefaultSolrJavaMem  = "-Xms1g -Xmx2g"
+	DefaultSolrOpts     = ""
+	DefaultSolrLogLevel = "INFO"
+	DefaultSolrGCTune   = ""
 
 	DefaultBusyBoxImageRepo    = "library/busybox"
 	DefaultBusyBoxImageVersion = "1.28.0-glibc"
@@ -87,6 +90,19 @@ type SolrCloudSpec struct {
 
 	// +optional
 	SolrJavaMem string `json:"solrJavaMem,omitempty"`
+
+	// You can add common system properties to the SOLR_OPTS environment variable
+	// SolrOpts is the string interface for these optional settings
+	// +optional
+	SolrOpts string `json:"solrOpts,omitempty"`
+
+	// Set the Solr Log level, defaults to INFO
+	// +optional
+	SolrLogLevel string `json:"solrLogLevel,omitempty"`
+
+	// Set GC Tuning configuration through GC_TUNE environment variable
+	// +optional
+	SolrGCTune string `json:"solrGCTune,omitempty"`
 }
 
 func (spec *SolrCloudSpec) withDefaults() (changed bool) {
@@ -99,6 +115,21 @@ func (spec *SolrCloudSpec) withDefaults() (changed bool) {
 	if spec.SolrJavaMem == "" {
 		changed = true
 		spec.SolrJavaMem = DefaultSolrJavaMem
+	}
+
+	if spec.SolrOpts == "" {
+		changed = true
+		spec.SolrOpts = DefaultSolrOpts
+	}
+
+	if spec.SolrLogLevel == "" {
+		changed = true
+		spec.SolrLogLevel = DefaultSolrLogLevel
+	}
+
+	if spec.SolrGCTune == "" {
+		changed = true
+		spec.SolrGCTune = DefaultSolrGCTune
 	}
 
 	if spec.ZookeeperRef == nil {

--- a/pkg/controller/util/solr_util.go
+++ b/pkg/controller/util/solr_util.go
@@ -202,7 +202,15 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, ingressBaseDomain string, ho
 								},
 								{
 									Name:  "SOLR_LOG_LEVEL",
-									Value: "INFO",
+									Value: solrCloud.Spec.SolrLogLevel,
+								},
+								{
+									Name:  "SOLR_OPTS",
+									Value: solrCloud.Spec.SolrOpts,
+								},
+								{
+									Name:  "GC_TUNE",
+									Value: solrCloud.Spec.SolrGCTune,
 								},
 							},
 							LivenessProbe: &corev1.Probe{


### PR DESCRIPTION
Signed-off-by: Zane Williamson <zanew@zillow.com>

*Issue number of the reported bug or feature request: https://github.com/bloomberg/solr-operator/issues/32

**Describe your changes**
Allow for optional adjustment of the SOLR_OPTS and GC_TUNE environment variables, provide example. Match up with current default behavior.

Allow for tunable logging

**Testing performed**
Local and development environment testing performed to ensure Solr on 8.2.0 applies the requested parameter changes.

