### PR TITLE
Adding router.field as optional input for SolrCollection creation

### DIFF
--- a/config/crds/solr_v1beta1_solrcollection.yaml
+++ b/config/crds/solr_v1beta1_solrcollection.yaml
@@ -51,6 +51,12 @@ spec:
               description: The replication factor to be used
               format: int64
               type: integer
+            routerField:
+              description: If this parameter is specified, the router will look at
+                the value of the field in an input document to compute the hash and
+                identify a shard instead of looking at the uniqueKey field. If the
+                field specified is null in the document, the document will be rejected.
+              type: string
             routerName:
               description: The router name that will be used. The router defines how
                 documents will be distributed

--- a/example/test_solrcloud.yaml
+++ b/example/test_solrcloud.yaml
@@ -17,6 +17,11 @@ spec:
   zookeeperRef:
     provided:
       zookeeper:
+        persistentVolumeClaimSpec:
+          storageClassName: "hostpath"
+          resources:
+            requests:
+              storage: "5Gi"
         replicas: 3 
         zookeeperPodPolicy:
           resources:

--- a/example/test_solrcollection.yaml
+++ b/example/test_solrcollection.yaml
@@ -34,6 +34,7 @@ spec:
   solrCloud: example
   collection: example-collection-3-implicit
   routerName: implicit
+  routerField: 'car'
   autoAddReplicas: true
   numShards: 2
   replicationFactor: 1

--- a/pkg/apis/solr/v1beta1/solrcollection_types.go
+++ b/pkg/apis/solr/v1beta1/solrcollection_types.go
@@ -35,6 +35,12 @@ type SolrCollectionSpec struct {
 	// +optional
 	RouterName string `json:"routerName,omitempty"`
 
+	// If this parameter is specified, the router will look at the value of the field in an input document
+	// to compute the hash and identify a shard instead of looking at the uniqueKey field.
+	// If the field specified is null in the document, the document will be rejected.
+	// +optional
+	RouterField string `json:"routerField,omitempty"`
+
 	// The num of shards to create, used if RouteName is compositeId
 	// +optional
 	NumShards int64 `json:"numShards,omitempty"`

--- a/pkg/controller/solrcollection/solrcollection_controller.go
+++ b/pkg/controller/solrcollection/solrcollection_controller.go
@@ -98,7 +98,7 @@ func (r *ReconcileSolrCollection) Reconcile(request reconcile.Request) (reconcil
 	oldStatus := collection.Status.DeepCopy()
 	requeueOrNot := reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}
 
-	solrCloud, collectionCreationStatus, err := reconcileSolrCollection(r, collection, collection.Spec.NumShards, collection.Spec.ReplicationFactor, collection.Spec.AutoAddReplicas, collection.Spec.MaxShardsPerNode, collection.Spec.RouterName, collection.Spec.Shards, collection.Spec.CollectionConfigName, collection.Namespace)
+	solrCloud, collectionCreationStatus, err := reconcileSolrCollection(r, collection, collection.Spec.NumShards, collection.Spec.ReplicationFactor, collection.Spec.AutoAddReplicas, collection.Spec.MaxShardsPerNode, collection.Spec.RouterName, collection.Spec.RouterField, collection.Spec.Shards, collection.Spec.CollectionConfigName, collection.Namespace)
 
 	if err != nil {
 		log.Error(err, "Error while creating SolrCloud collection")
@@ -166,7 +166,7 @@ func (r *ReconcileSolrCollection) Reconcile(request reconcile.Request) (reconcil
 	return requeueOrNot, nil
 }
 
-func reconcileSolrCollection(r *ReconcileSolrCollection, collection *solrv1beta1.SolrCollection, numShards int64, replicationFactor int64, autoAddReplicas bool, maxShardsPerNode int64, routerName string, shards string, collectionConfigName string, namespace string) (solrCloud *solrv1beta1.SolrCloud, collectionCreationStatus bool, err error) {
+func reconcileSolrCollection(r *ReconcileSolrCollection, collection *solrv1beta1.SolrCollection, numShards int64, replicationFactor int64, autoAddReplicas bool, maxShardsPerNode int64, routerName string, routerField string, shards string, collectionConfigName string, namespace string) (solrCloud *solrv1beta1.SolrCloud, collectionCreationStatus bool, err error) {
 	// Get the solrCloud that this collection is for.
 	solrCloud = &solrv1beta1.SolrCloud{}
 	err = r.Get(context.TODO(), types.NamespacedName{Namespace: collection.Namespace, Name: collection.Spec.SolrCloud}, solrCloud)
@@ -198,7 +198,7 @@ func reconcileSolrCollection(r *ReconcileSolrCollection, collection *solrv1beta1
 
 		// Request the creation of collection by calling solr
 		collection.Status.InProgressCreation = true
-		create, err := util.CreateCollection(solrCloud.Name, collection.Name, numShards, replicationFactor, autoAddReplicas, routerName, shards, collectionConfigName, namespace)
+		create, err := util.CreateCollection(solrCloud.Name, collection.Name, numShards, replicationFactor, autoAddReplicas, routerName, routerField, shards, collectionConfigName, namespace)
 		if err != nil {
 			collection.Status.InProgressCreation = false
 			return nil, false, err

--- a/pkg/controller/util/collection_util.go
+++ b/pkg/controller/util/collection_util.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CreateCollection to request collection creation on SolrCloud
-func CreateCollection(cloud string, collection string, numShards int64, replicationFactor int64, autoAddReplicas bool, routerName string, shards string, collectionConfigName string, namespace string) (success bool, err error) {
+func CreateCollection(cloud string, collection string, numShards int64, replicationFactor int64, autoAddReplicas bool, routerName string, routerField string, shards string, collectionConfigName string, namespace string) (success bool, err error) {
 	queryParams := url.Values{}
 	replicationFactorParameter := strconv.FormatInt(replicationFactor, 10)
 	numShardsParameter := strconv.FormatInt(numShards, 10)
@@ -31,6 +31,7 @@ func CreateCollection(cloud string, collection string, numShards int64, replicat
 	queryParams.Add("replicationFactor", replicationFactorParameter)
 	queryParams.Add("autoAddReplicas", strconv.FormatBool(autoAddReplicas))
 	queryParams.Add("collection.configName", collectionConfigName)
+	queryParams.Add("router.field", routerField)
 
 	if routerName == "implicit" {
 		queryParams.Add("router.name", routerName)


### PR DESCRIPTION
Signed-off-by: Zane Williamson <zanew@zillow.com>

*Issue number of the reported bug or feature request: #42 

**Describe your changes**
Add optional router.field for SolrCollection creation. This isn't modifiable after collection creation.

**Testing performed**
```
---
apiVersion: solr.bloomberg.com/v1beta1
kind: SolrCollection
metadata:
  name: example-collection-3-implicit
spec:
  solrCloud: example
  collection: example-collection-3-implicit-with-router-field
  routerName: implicit
  routerField: 'car'
  autoAddReplicas: true
  numShards: 2
  replicationFactor: 1
  maxShardsPerNode: 1
  shards: "fooshard1,fooshard2"
```

Ensured field name showed up in 
```
curl "http://default-example-solrcloud.ing.local.domain/solr/admin/collections?action=CLUSTERSTATUS&collection=example-collection-3-implicit"
```

```
--snip--
        "router":{
          "field":"car",
          "name":"implicit"},
--snip--
```

ensured collection creation and deleting worked as intended
