### PR TITLE
Add new customization API

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -1,0 +1,138 @@
+package v1beta1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+// StatefulSetOptions defines custom options for StatefulSets
+type StatefulSetOptions struct {
+	// Annotations to be added for the solrCloud Services.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels to be added for the solrCloud Services.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// PodOptions defines the common pod configuration for Pods, including when used
+// in deployments, stateful-sets, etc.
+type PodOptions struct {
+	// The scheduling constraints on pods.
+	// +optional
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+
+	// Resources is the resource requirements for the container.
+	// This field cannot be updated once the cluster is created.
+	// +optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// Additional non-data volumes to load into the default container.
+	// +optional
+	Volumes []AdditionalVolume `json:"volumes,omitempty"`
+
+	// PodSecurityContext is the security context for the pod.
+	// +optional
+	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+
+	// Additional environment variables to pass to the default container.
+	// +optional
+	EnvVariable []corev1.EnvVar `json:"envVars,omitempty"`
+
+	// Annotations to be added for pods.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels to be added for pods.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// ServiceOptions defines custom options for services
+type ServiceOptions struct {
+	// Annotations to be added for the solrCloud Services.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels to be added for the solrCloud Services.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// IngressOptions defines custom options for ingresses
+type IngressOptions struct {
+	// Annotations to be added for the solrCloud Ingress.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels to be added for the solrCloud Ingress.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// ConfigMapOptions defines custom options for configMaps
+type ConfigMapOptions struct {
+	// Annotations to be added for the solrCloud ConfigMap.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels to be added for the solrCloud ConfigMap.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// AdditionalVolume provides information on additional volumes that should be loaded into pods
+type AdditionalVolume struct {
+	// Name of the volume
+	Name string `json:"name"`
+
+	// Source is the source of the Volume to be loaded into the solrCloud Pod
+	Source corev1.VolumeSource `json:"source,omitempty"`
+
+	// DefaultContainerMount defines how to mount this volume into the default container.
+	DefaultContainerMount corev1.VolumeMount `json:"defaultContainerMount"`
+}
+
+
+// ContainerImage defines the fields needed for a Docker repository image. The
+// format here matches the predominant format used in Helm charts.
+type ContainerImage struct {
+	// +optional
+	Repository string `json:"repository,omitempty"`
+	// +optional
+	Tag string `json:"tag,omitempty"`
+	// +optional
+	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
+	// +optional
+	ImagePullSecret string `json:"imagePullSecret,omitempty"`
+}
+
+func (c *ContainerImage) withDefaults(repo string, version string, policy corev1.PullPolicy) (changed bool) {
+	if c.Repository == "" {
+		changed = true
+		c.Repository = repo
+	}
+	if c.Tag == "" {
+		changed = true
+		c.Tag = version
+	}
+	if c.PullPolicy == "" {
+		changed = true
+		c.PullPolicy = policy
+	}
+	return changed
+}
+
+func (c *ContainerImage) ToImageName() (name string) {
+	return c.Repository + ":" + c.Tag
+}
+
+func ImageVersion(image string) (version string) {
+	split := strings.Split(image, ":")
+	if len(split) < 2 {
+		return ""
+	} else {
+		return split[1]
+	}
+}

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -74,11 +74,6 @@ type SolrCloudSpec struct {
 	// +optional
 	SolrImage *ContainerImage `json:"solrImage,omitempty"`
 
-	// Pod defines the policy to create pod for the SolrCloud.
-	// Updating the Pod does not take effect on any existing pods.
-	// +optional
-	SolrPod SolrPodPolicy `json:"solrPodPolicy,omitempty"`
-
 	// DataPvcSpec is the spec to describe PVC for the solr node to store its data.
 	// This field is optional. If no PVC spec is provided, each solr node will use emptyDir as the data volume
 	// +optional
@@ -92,6 +87,14 @@ type SolrCloudSpec struct {
 	// Other options are to use a NFS volume.
 	// +optional
 	BackupRestoreVolume *corev1.VolumeSource `json:"backupRestoreVolume,omitempty"`
+
+	// Provide custom options for kubernetes objects created for the Solr Cloud.
+	// +optional
+	CustomSolrKubeOptions CustomSolrKubeOptions `json:"customSolrKubeOptions,omitempty"`
+
+	// Customize how Solr is addressed both internally and externally in kubernetes.
+	// +optional
+	SolrAddressabilityOptions SolrAddressabilityOptions `json:"solrAddressabilityOptions,omitempty"`
 
 	// +optional
 	BusyBoxImage *ContainerImage `json:"busyBoxImage,omitempty"`
@@ -175,60 +178,92 @@ func (spec *SolrCloudSpec) withDefaults() (changed bool) {
 	return changed
 }
 
-// SolrPodPolicy defines the common pod configuration for Pods, including when used
-// in deployments, stateful-sets, etc.
-type SolrPodPolicy struct {
-	// The scheduling constraints on pods.
+type CustomSolrKubeOptions struct {
+	// SolrPodOptions defines the custom options for solrCloud pods.
 	// +optional
-	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	PodOptions *PodOptions `json:"podOptions,omitempty"`
 
-	// Resources is the resource requirements for the container.
-	// This field cannot be updated once the cluster is created.
+	// StatefulSetOptions defines the custom options for the solrCloud StatefulSet.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	StatefulSetOptions *StatefulSetOptions `json:"statefulSetOptions,omitempty"`
+
+	// CommonServiceOptions defines the custom options for the common solrCloud Service.
+	// +optional
+	CommonServiceOptions *ServiceOptions `json:"commonServiceOptions,omitempty"`
+
+	// HeadlessServiceOptions defines the custom options for the headless solrCloud Service.
+	// +optional
+	HeadlessServiceOptions *ServiceOptions `json:"headlessServiceOptions,omitempty"`
+
+	// NodeServiceOptions defines the custom options for the individual solrCloud Node services, if they are created.
+	// These services will only be created when exposing SolrNodes externally in the AddressabilityOptions.
+	// +optional
+	NodeServiceOptions *ServiceOptions `json:"headlessServiceOptions,omitempty"`
+
+	// ServiceOptions defines the custom options for solrCloud Services.
+	// +optional
+	ConfigMapOptions *ConfigMapOptions `json:"configMapOptions,omitempty"`
+
+	// IngressOptions defines the custom options for solrCloud Ingress.
+	// +optional
+	IngressOptions *IngressOptions `json:"ingressOptions,omitempty"`
 }
 
-// ContainerImage defines the fields needed for a Docker repository image. The
-// format here matches the predominant format used in Helm charts.
-type ContainerImage struct {
+type SolrAddressabilityOptions struct {
+	// The way in which this SolrCloud nodes should be made addressable externally.
+	// If none is provided, nodes will not be addressable externally.
 	// +optional
-	Repository string `json:"repository,omitempty"`
+	External *ExternalAddressability `json:"externalOptions,omitempty"`
+
+	// PodPort defines the port to have the Solr Pod listen on.
+	// Defaults to 8983
 	// +optional
-	Tag string `json:"tag,omitempty"`
+	PodPort int `json:"podPort,omitempty"`
+
+	// ServicePort defines the port to have all Solr services listen on. This is the port Solr will advertise itself as.
+	// Defaults to 80
 	// +optional
-	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
-	// +optional
-	ImagePullSecret string `json:"imagePullSecret,omitempty"`
+	ServicePort int `json:"servicePort,omitempty"`
 }
 
-func (c *ContainerImage) withDefaults(repo string, version string, policy corev1.PullPolicy) (changed bool) {
-	if c.Repository == "" {
-		changed = true
-		c.Repository = repo
-	}
-	if c.Tag == "" {
-		changed = true
-		c.Tag = version
-	}
-	if c.PullPolicy == "" {
-		changed = true
-		c.PullPolicy = policy
-	}
-	return changed
+// ExternalAddressability defines the config for making Solr services available externally to kubernetes.
+// Be careful when using LoadBalanced and includeNodes, as many IP addresses could be created if you are running many large solrClouds.
+type ExternalAddressability struct {
+	// The way in which this SolrCloud service(s) should be made addressable externally.
+	Method ExternalAddressabilityMethod `json:"method"`
+
+	// Expose the common Solr service externally. This is a single service.
+	// +optional
+	ExposeCommon bool `json:"exposeCommon"`
+
+	// Expose each of the Solr Node services externally. This is equal to the number of Solr nodes running within the statefulSet.
+	// +optional
+	ExposeNodes bool `json:"ExposeNodes"`
+
+	// Override the baseDomain provided as startup parameters to the operator, used by ingresses and externalDNS
+	// +optional
+	BaseDomain string `json:"baseDomain,omitempty"`
+
+	// Provide additional baseDomains that ingresses or ExternalDNS should listen on.
+	// +optional
+	AdditionalBaseDomains []string `json:"additionalDomains,omitempty"`
+
+	// UseExternalDNS for services and/or ingresses. Defaults to false
+	// +optional
+	UseExternalDNS bool `json:"useExternalDNS,omitempty"`
 }
 
-func (c *ContainerImage) ToImageName() (name string) {
-	return c.Repository + ":" + c.Tag
-}
+// ExternalAddressability is a string enumeration type that enumerates
+// all possible ways that a SolrCloud can be made addressable external to the kubernetes cluster.
+type ExternalAddressabilityMethod string
 
-func ImageVersion(image string) (version string) {
-	split := strings.Split(image, ":")
-	if len(split) < 2 {
-		return ""
-	} else {
-		return split[1]
-	}
-}
+const (
+	// Use an ingress to make the Solr services externally addressable
+	Ingress = "Ingress"
+
+	// Use LoadBalancedServices to make the Solr services externally addressable
+	LoadBalancedService = "LoadBalancedService"
+)
 
 // ZookeeperRef defines the zookeeper ensemble for solr to connect to
 // If no ConnectionString is provided, the solr-cloud controller will create and manage an internal ensemble


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #63, #55, #36, #32*

**Describe your changes**
This is a PR to framework all of the new configuration options that we want to implement.

We can split further implementation into separate PRs, but I want to agree on API before any implementation is done.

Also the only customization supported currently is the SolrCloud object, not ZK, Zetcd, Solr Prometheus Exporter, etc. So we will also need separate PRs/Issues to deal with those. But I think that Solr should be the first we tackle it for.

**Testing performed**
Still need to write tests, and do implementation. We will likely need to write a very flexible testing framework so that all of these dozens of options can be tested completely.