### PR TITLE
Adding a service account when running the operator.

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         control-plane: solr-operator 
     spec:
+      serviceAccountName: solr-operator
       containers:
       - args:
         - -zk-operator=true

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml
@@ -6,6 +7,6 @@ resources:
 # Comment the following 3 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
+# - auth_proxy_service.yaml
+# - auth_proxy_role.yaml
+# - auth_proxy_role_binding.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: solr-operator
+  namespace: default

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: solr-operator-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: solr-operator
+  namespace: default

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: solr-operator
+  namespace: default


### PR DESCRIPTION
Right now the default service account is used, which gives all controller permissions to every default pod in the default namespace.
