### PR TITLE
Adding in maxShardsPerNode when creating collection.

### DIFF
--- a/controllers/solrcollection_controller.go
+++ b/controllers/solrcollection_controller.go
@@ -169,7 +169,7 @@ func reconcileSolrCollection(r *SolrCollectionReconciler, collection *solrv1beta
 
 		// Request the creation of collection by calling solr
 		collection.Status.InProgressCreation = true
-		create, err := util.CreateCollection(solrCloud.Name, collection.Name, numShards, replicationFactor, autoAddReplicas, routerName, routerField, shards, collectionConfigName, namespace)
+		create, err := util.CreateCollection(solrCloud.Name, collection.Name, numShards, replicationFactor, autoAddReplicas, maxShardsPerNode, routerName, routerField, shards, collectionConfigName, namespace)
 		if err != nil {
 			collection.Status.InProgressCreation = false
 			return nil, false, err

--- a/controllers/util/collection_util.go
+++ b/controllers/util/collection_util.go
@@ -23,13 +23,15 @@ import (
 )
 
 // CreateCollection to request collection creation on SolrCloud
-func CreateCollection(cloud string, collection string, numShards int64, replicationFactor int64, autoAddReplicas bool, routerName string, routerField string, shards string, collectionConfigName string, namespace string) (success bool, err error) {
+func CreateCollection(cloud string, collection string, numShards int64, replicationFactor int64, autoAddReplicas bool, maxShardsPerNode int64, routerName string, routerField string, shards string, collectionConfigName string, namespace string) (success bool, err error) {
 	queryParams := url.Values{}
 	replicationFactorParameter := strconv.FormatInt(replicationFactor, 10)
 	numShardsParameter := strconv.FormatInt(numShards, 10)
+	maxShardsPerNodeParameter := strconv.FormatInt(maxShardsPerNode, 10)
 	queryParams.Add("action", "CREATE")
 	queryParams.Add("name", collection)
 	queryParams.Add("replicationFactor", replicationFactorParameter)
+	queryParams.Add("maxShardsPerNode", maxShardsPerNodeParameter)
 	queryParams.Add("autoAddReplicas", strconv.FormatBool(autoAddReplicas))
 	queryParams.Add("collection.configName", collectionConfigName)
 	queryParams.Add("router.field", routerField)


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #49*

**Describe your changes**
MaxShardsPerNode is taken into account when updating a collection, however not when a collection is being created. This is a fix for that.