### PR TITLE
Add Kubernetes NodeName information to SolrNode status

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -552,7 +552,10 @@ type SolrCloudStatus struct {
 // and internal and external addresses
 type SolrNodeStatus struct {
 	// The name of the pod running the node
-	NodeName string `json:"name"`
+	Name string `json:"name"`
+
+	// The name of the Kubernetes Node which the pod is running on
+	NodeName string `json:"nodeName"`
 
 	// An address the node can be connected to from within the Kube cluster
 	InternalAddress string `json:"internalAddress"`

--- a/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
+++ b/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
@@ -7078,6 +7078,10 @@ spec:
                   name:
                     description: The name of the pod running the node
                     type: string
+                  nodeName:
+                    description: The name of the Kubernetes Node which the pod is
+                      running on
+                    type: string
                   ready:
                     description: Is the node up and running
                     type: boolean
@@ -7087,6 +7091,7 @@ spec:
                 required:
                 - internalAddress
                 - name
+                - nodeName
                 - ready
                 - version
                 type: object

--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -321,10 +321,11 @@ func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, new
 	for idx, p := range foundPods.Items {
 		nodeNames[idx] = p.Name
 		nodeStatus := solr.SolrNodeStatus{}
-		nodeStatus.NodeName = p.Name
+		nodeStatus.Name = p.Name
+		nodeStatus.NodeName = p.Spec.NodeName
 		nodeStatus.InternalAddress = "http://" + solrCloud.InternalNodeUrl(nodeStatus.NodeName, IngressBaseUrl == "", true)
 		if IngressBaseUrl != "" {
-			nodeStatus.ExternalAddress = "http://" + solrCloud.NodeIngressUrl(nodeStatus.NodeName, IngressBaseUrl)
+			nodeStatus.ExternalAddress = "http://" + solrCloud.NodeIngressUrl(nodeStatus.Name, IngressBaseUrl)
 		}
 		ready := false
 		if len(p.Status.ContainerStatuses) > 0 {
@@ -341,7 +342,7 @@ func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, new
 		}
 		nodeStatus.Ready = ready
 
-		nodeStatusMap[nodeStatus.NodeName] = nodeStatus
+		nodeStatusMap[nodeStatus.Name] = nodeStatus
 
 		// Get Volumes for backup/restore
 		if solrCloud.Spec.BackupRestoreVolume != nil {

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -8556,6 +8556,10 @@ spec:
                   name:
                     description: The name of the pod running the node
                     type: string
+                  nodeName:
+                    description: The name of the Kubernetes Node which the pod is
+                      running on
+                    type: string
                   ready:
                     description: Is the node up and running
                     type: boolean
@@ -8565,6 +8569,7 @@ spec:
                 required:
                 - internalAddress
                 - name
+                - nodeName
                 - ready
                 - version
                 type: object


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Resolves #88*

**Describe your changes**
Adding an entry to the SolrNodeStatus for the name of the kubernetes node that the pod is running on.

**Testing performed**
Ran on a cluster and the nodeName information was populated correctly.
