### PR TITLE
Fixed usage of empty routerField and made routerName an enum.

### DIFF
--- a/api/v1beta1/solrcollection_types.go
+++ b/api/v1beta1/solrcollection_types.go
@@ -33,7 +33,7 @@ type SolrCollectionSpec struct {
 
 	// The router name that will be used. The router defines how documents will be distributed
 	// +optional
-	RouterName string `json:"routerName,omitempty"`
+	RouterName CollectionRouterName `json:"routerName,omitempty"`
 
 	// If this parameter is specified, the router will look at the value of the field in an input document
 	// to compute the hash and identify a shard instead of looking at the uniqueKey field.
@@ -61,6 +61,18 @@ type SolrCollectionSpec struct {
 	// +optional
 	AutoAddReplicas bool `json:"autoAddReplicas,omitempty"`
 }
+
+// CollectionRouterName is a string enumeration type that enumerates the ways that documents can be routed for a collection.
+// +kubebuilder:validation:Enum=implicit;compositeId
+type CollectionRouterName string
+
+const (
+	// The Implicit router
+	ImplicitRouter CollectionRouterName = "implicit"
+
+	// The CompositeId router
+	CompositeIdRouter CollectionRouterName = "compositeId"
+)
 
 // SolrCollectionStatus defines the observed state of SolrCollection
 type SolrCollectionStatus struct {

--- a/config/crd/bases/solr.bloomberg.com_solrcollections.yaml
+++ b/config/crd/bases/solr.bloomberg.com_solrcollections.yaml
@@ -66,6 +66,9 @@ spec:
             routerName:
               description: The router name that will be used. The router defines how
                 documents will be distributed
+              enum:
+              - implicit
+              - compositeId
               type: string
             shards:
               description: A comma separated list of shard names, e.g., shard-x,shard-y,shard-z.

--- a/controllers/solrcollection_controller.go
+++ b/controllers/solrcollection_controller.go
@@ -135,7 +135,7 @@ func (r *SolrCollectionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	return requeueOrNot, nil
 }
 
-func reconcileSolrCollection(r *SolrCollectionReconciler, collection *solrv1beta1.SolrCollection, numShards int64, replicationFactor int64, autoAddReplicas bool, maxShardsPerNode int64, routerName string, routerField string, shards string, collectionConfigName string, namespace string) (solrCloud *solrv1beta1.SolrCloud, collectionCreationStatus bool, err error) {
+func reconcileSolrCollection(r *SolrCollectionReconciler, collection *solrv1beta1.SolrCollection, numShards int64, replicationFactor int64, autoAddReplicas bool, maxShardsPerNode int64, routerName solrv1beta1.CollectionRouterName, routerField string, shards string, collectionConfigName string, namespace string) (solrCloud *solrv1beta1.SolrCloud, collectionCreationStatus bool, err error) {
 	// Get the solrCloud that this collection is for.
 	solrCloud = &solrv1beta1.SolrCloud{}
 	if err = r.Get(context.TODO(), types.NamespacedName{Namespace: collection.Namespace, Name: collection.Spec.SolrCloud}, solrCloud); err != nil {

--- a/controllers/util/collection_util.go
+++ b/controllers/util/collection_util.go
@@ -17,13 +17,14 @@ limitations under the License.
 package util
 
 import (
+	solr "github.com/bloomberg/solr-operator/api/v1beta1"
 	"net/url"
 	"strconv"
 	"strings"
 )
 
 // CreateCollection to request collection creation on SolrCloud
-func CreateCollection(cloud string, collection string, numShards int64, replicationFactor int64, autoAddReplicas bool, maxShardsPerNode int64, routerName string, routerField string, shards string, collectionConfigName string, namespace string) (success bool, err error) {
+func CreateCollection(cloud string, collection string, numShards int64, replicationFactor int64, autoAddReplicas bool, maxShardsPerNode int64, routerName solr.CollectionRouterName, routerField string, shards string, collectionConfigName string, namespace string) (success bool, err error) {
 	queryParams := url.Values{}
 	replicationFactorParameter := strconv.FormatInt(replicationFactor, 10)
 	numShardsParameter := strconv.FormatInt(numShards, 10)
@@ -34,16 +35,19 @@ func CreateCollection(cloud string, collection string, numShards int64, replicat
 	queryParams.Add("maxShardsPerNode", maxShardsPerNodeParameter)
 	queryParams.Add("autoAddReplicas", strconv.FormatBool(autoAddReplicas))
 	queryParams.Add("collection.configName", collectionConfigName)
-	queryParams.Add("router.field", routerField)
 
-	if routerName == "implicit" {
-		queryParams.Add("router.name", routerName)
+	if routerName == solr.ImplicitRouter {
+		queryParams.Add("router.name", string(routerName))
 		queryParams.Add("shards", shards)
-	} else if routerName == "compositeId" {
-		queryParams.Add("router.name", routerName)
+	} else if routerName == solr.CompositeIdRouter {
+		queryParams.Add("router.name", string(routerName))
 		queryParams.Add("numShards", numShardsParameter)
 	} else {
 		log.Info("router.name must be either compositeId or implicit. Provided: ", "router.name", routerName)
+	}
+
+	if routerField != "" {
+		queryParams.Add("router.field", routerField)
 	}
 
 	resp := &SolrAsyncResponse{}

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -8768,6 +8768,9 @@ spec:
             routerName:
               description: The router name that will be used. The router defines how
                 documents will be distributed
+              enum:
+              - implicit
+              - compositeId
               type: string
             shards:
               description: A comma separated list of shard names, e.g., shard-x,shard-y,shard-z.


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Fixes #97*

**Describe your changes**
`routerField` is no longer added to the Solr Collections API call if it is empty.
Also changed `routerName` to be an enum, as there are only 2 possible options for this field.