### PR TITLE
Adding hosted helm chart with deployment script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 bin
+release-artifacts
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ clean:
 mod-tidy:
 	export GO111MODULE=on; go mod tidy
 
+release:
+	VERSION=${VERSION} bash hack/setup_release.sh
+
 ###
 # Building
 ###

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 mod-tidy:
 	export GO111MODULE=on; go mod tidy
 
-release:
+release: manifests
 	VERSION=${VERSION} bash hack/setup_release.sh
 
 ###

--- a/docs/charts/index.yaml
+++ b/docs/charts/index.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+entries:
+  solr-operator:
+  - apiVersion: v1
+    appVersion: v0.2.5
+    created: "2020-05-08T15:36:08.674546-04:00"
+    description: The Solr Operator enables easy management of Solr resources within
+      Kubernetes.
+    digest: c84c14e8d68b74a6084ee4a730128122e5c093c82ff8e4b549c613f4a5500110
+    home: https://github.com/bloomberg/solr-operator
+    icon: https://lucene.apache.org/theme/images/solr/identity/Solr_Logo_on_white.png
+    keywords:
+    - solr
+    - apache
+    - search
+    - lucene
+    - operator
+    kubeVersion: '>= 1.13.0'
+    maintainers:
+    - email: houston@apache.org
+      name: Houston Putman
+    name: solr-operator
+    sources:
+    - https://github.com/bloomberg/solr-operator
+    type: application
+    urls:
+    - https://github.com/bloomberg/solr-operator/releases/download/v0.2.5/solr-operator-0.2.5.tgz
+    version: 0.2.5
+generated: "2020-05-08T15:36:08.667217-04:00"

--- a/docs/charts/index.yaml
+++ b/docs/charts/index.yaml
@@ -3,10 +3,10 @@ entries:
   solr-operator:
   - apiVersion: v1
     appVersion: v0.2.5
-    created: "2020-05-08T15:36:08.674546-04:00"
+    created: "2020-05-08T18:03:36.734334-04:00"
     description: The Solr Operator enables easy management of Solr resources within
       Kubernetes.
-    digest: c84c14e8d68b74a6084ee4a730128122e5c093c82ff8e4b549c613f4a5500110
+    digest: b6cfb98aa7d77999310ee82c7b706e572c823e5c25fe5ddceb6454b2413d3541
     home: https://github.com/bloomberg/solr-operator
     icon: https://lucene.apache.org/theme/images/solr/identity/Solr_Logo_on_white.png
     keywords:
@@ -26,4 +26,4 @@ entries:
     urls:
     - https://github.com/bloomberg/solr-operator/releases/download/v0.2.5/solr-operator-0.2.5.tgz
     version: 0.2.5
-generated: "2020-05-08T15:36:08.667217-04:00"
+generated: "2020-05-08T18:03:36.728994-04:00"

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,11 +4,11 @@ This page details the steps for developing the Solr Operator, and all necessary 
 
  - [Setup](#setup)
     - [Setup Docker for Mac with K8S](#setup-docker-for-mac-with-k8s-with-an-ingress-controller)
-    - [Install the necessary Dependencies](#installing-the-necessary-dependencies)
+    - [Install the necessary Dependencies](#install-the-necessary-dependencies)
  - [Build the Solr CRDs](#build-the-solr-crds)
- - [Build and Run the Solr Operator](#build-and-run-the-solr-operator)
-    - [Build the Solr Operator](#)
-    - [Running the Solr Operator](#R)
+ - [Build and Run the Solr Operator](#build-and-run-local-versions)
+    - [Build the Solr Operator](#building-the-solr-operator)
+    - [Running the Solr Operator](#running-the-solr-operator)
  - [Steps to take before creating a PR](#before-you-create-a-pr)
  
 ## Setup
@@ -20,7 +20,7 @@ Please follow the instructions from the [local tutorial](local_tutorial.md#setup
 ### Install the necessary dependencies
 
 Install the Zookeeper & Etcd Operators, which this operator depends on by default.
-Each is optional, as described in the [Zookeeper](#zookeeper-reference) section.
+Each is optional, as described in the [Zookeeper Reference](solr-cloud/solr-cloud-crd.md#zookeeper-reference) section in the CRD docs.
 
 ```bash
 $ kubectl apply -f example/dependencies

--- a/docs/release-instructions.md
+++ b/docs/release-instructions.md
@@ -37,11 +37,13 @@ This will do the following steps:
 1. Build the CRDs and copy them into the Helm chart.
 1. Package up the helm charts and index them in `docs/charts/index.yaml`.
 1. Create all artifacts that should be included in the Github Release, and place them in the `/release-artifacts` directory.
+1. Commits all necessary changes for the release.
 
 ### Create a release PR and merge into `master`
 
-Once you have created the commit, you can push it to your fork and create a PR against the `master` branch.
-If the Travis tests pass, merge it into master.
+Now you need to merge the release commit into master.
+You can push it to your fork and create a PR against the `master` branch.
+If the Travis tests pass, "Squash and Merge" it into master.
 
 ### Tag and publish the release
 

--- a/docs/release-instructions.md
+++ b/docs/release-instructions.md
@@ -1,0 +1,55 @@
+# Releasing a New Verson of the Solr Operator
+
+This page details the steps for releasing new versions of the Solr Operator.
+
+- [Versioning](#versioning)
+  - [Backwards Compatibility](#backwards-compatibility)
+- [Create the Upgrade Commit](#create-the-upgrade-commit)
+- [Create a release PR and merge into `master`](#create-a-release-pr-and-merge-into-master)
+- [Tag and publish the release](#tag-and-publish-the-release)
+ 
+### Versioning
+
+The Solr Operator follows kubernetes conventions with versioning with is:
+
+`v<Major>.<Minor>.<Patch>`
+
+For example `v0.2.5` or `v1.3.4`.
+Certain systems except versions that do not start wth `v`, such as Helm.
+However the tooling has been created to automatically make these changes when necessary, so always include the prefixed `v` when following these instructions.
+
+#### Backwards Compatibility
+
+All patch versions of the same major & minor version should be backwards compatabile.
+Non-backwards compatible changes will be allowed while the Solr Operator is still in a beta state.
+ 
+### Create the upgrade commit
+
+The last commit of a release version of the Solr Operator should be made via the following command.
+
+```bash
+$ VERSION=<version> make release
+```
+
+This will do the following steps:
+
+1. Set the variables of the Helm chart to be the new version.
+1. Build the CRDs and copy them into the Helm chart.
+1. Package up the helm charts and index them in `docs/charts/index.yaml`.
+1. Create all artifacts that should be included in the Github Release, and place them in the `/release-artifacts` directory.
+
+### Create a release PR and merge into `master`
+
+Once you have created the commit, you can push it to your fork and create a PR against the `master` branch.
+If the Travis tests pass, merge it into master.
+
+### Tag and publish the release
+
+In order to create a release, you can do it entirely through the Github UI.
+Go to the releases tab, and click "Draft a new Release".
+
+Follow the formatting of previous releases, showing the highlights of changes in that version nicluding links to relevant PRs.
+
+Before publishing, make sure to attach all of the artifacts from the `release-artifacts` directory that were made when running the `make release` command earlier in the guide.
+
+Once you publish the release, Travis should re-run and deploy the docker containers to docker hub.

--- a/hack/setup_release.sh
+++ b/hack/setup_release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+echo "Setting up Release ${VERSION}"
+
+# Update default solr-operator version and the helm chart versions.
+gawk -i inplace '$1 == "repository:" { tag = ($2 == "bloomberg/solr-operator") }
+tag && $1 == "tag:"{$1 = "  " $1; $2 = "'"${VERSION}"'"} 1' helm/solr-operator/values.yaml
+
+gawk -i inplace '$1 == "version:"{$1 = $1; $2 = "'"${VERSION#v}"'"} 1' helm/solr-operator/Chart.yaml
+gawk -i inplace '$1 == "appVersion:"{$1 = $1; $2 = "'"${VERSION}"'"} 1' helm/solr-operator/Chart.yaml
+
+
+# Package and Index the helm charts, create release artifacts to upload in GithubRelease
+mkdir -p release-artifacts
+
+rm -rf release-artifacts/*
+
+helm package helm/* --app-version "${VERSION}" --version "${VERSION#v}" -d release-artifacts/
+
+helm repo index release-artifacts/ --url https://github.com/bloomberg/solr-operator/releases/download/${VERSION}/ --merge docs/charts/index.yaml
+
+mv release-artifacts/index.yaml docs/charts/index.yaml
+
+cp config/crd/bases/* release-artifacts/.

--- a/hack/setup_release.sh
+++ b/hack/setup_release.sh
@@ -28,3 +28,7 @@ helm repo index release-artifacts/ --url https://github.com/bloomberg/solr-opera
 mv release-artifacts/index.yaml docs/charts/index.yaml
 
 cp config/crd/bases/* release-artifacts/.
+
+git add helm config docs
+
+git commit -asm "Cutting release version ${VERSION} of the Solr Operator"

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -1,6 +1,21 @@
 
 apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart Solr Operator
+type: application
 name: solr-operator
-version: 0.1.0
+description: The Solr Operator enables easy management of Solr resources within Kubernetes.
+version: 0.2.5
+appVersion: v0.2.5
+kubeVersion: ">= 1.13.0"
+home: https://github.com/bloomberg/solr-operator
+sources:
+  - https://github.com/bloomberg/solr-operator
+keywords:
+  - solr
+  - apache
+  - search
+  - lucene
+  - operator
+maintainers:
+  - name: Houston Putman
+    email: houston@apache.org
+icon: https://lucene.apache.org/theme/images/solr/identity/Solr_Logo_on_white.png

--- a/helm/solr-operator/LICENSE
+++ b/helm/solr-operator/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -2,7 +2,15 @@ Solr Operator
 =============
 A Helm chart for the Solr Operator.
 
-## Installing the Chart
+## The Solr Operator
+
+The Solr Operator is designed to allow easy deployment Solr Clouds and other Solr Resources to Kubernetes.
+
+Documentation around using the Solr Operator can be found in it's [source repo](https://github.com/bloomberg/solr-operator).
+
+## Using the Helm Chart
+
+### Installing the Chart
 
 To install the chart with the release name `test`:
 
@@ -10,13 +18,13 @@ To install the chart with the release name `test`:
 $ helm install test .
 ```
 
-The command deploys the solr-operator on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys the solr-operator on the Kubernetes cluster with the default configuration. The [configuration](#chart-values) section lists the parameters that can be configured during installation.
 
 **NOTE**: Since by default the `useZkOperator` option is set to `True`, you must have already installed the [Zookeeper Operator](https://github.com/pravega/zookeeper-operator) in your kubernetes cluster. A helm chart is [also available](https://github.com/pravega/zookeeper-operator/blob/master/charts/zookeeper-operator/Chart.yaml) for it.
 
-## Helm Version Differences
+### Helm Version Differences
 
-### Helm 2
+#### Helm 2
 
 If you are using Helm 2, CRDs are installed using the crd-install hook. Prior to installing, you'll need to uncomment the last two lines in [kustomization.yaml](../../config/crd/kustomization.yaml), and run `make manifests`
 
@@ -26,21 +34,21 @@ You will also need to update the install command to use the name flag, as shown 
 $ helm install --name test .
 ```
 
-### Helm 3
+#### Helm 3
 
 Helm 3 automatically runs CRDs in the /crds directory, no further action is needed.
 
-## Uninstalling the Chart
+### Uninstalling the Chart
 
 To uninstall/delete the `solr-operator` deployment:
 
-### Helm 3
+#### Helm 3
 
 ```console
 $ helm uninstall test
 ```
 
-### Helm 2
+#### Helm 2
 
 ```console
 $ helm delete test

--- a/helm/solr-operator/README.md
+++ b/helm/solr-operator/README.md
@@ -1,4 +1,4 @@
-solr-operator
+Solr Operator
 =============
 A Helm chart for the Solr Operator.
 

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: bloomberg/solr-operator
-  tag: latest
+  tag: v0.2.5
   pullPolicy: Always
 
 nameOverride: ""


### PR DESCRIPTION
This is a PR to host a helm repo in the github pages of this github repository (bloomberg.github.io/solr-operator/charts). 

I still need to fix the documentation in the getting started, and add documentation around doing releases. But I think the logic should be there.