### PR TITLE
Allow "pre-release" Kube versions in Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,15 @@ version:
 
 clean:
 	rm -rf ./bin
+	rm -rf ./release-artifacts
 
 mod-tidy:
 	export GO111MODULE=on; go mod tidy
 
-release: manifests helm-check
-	VERSION=${VERSION} bash hack/setup_release.sh
+release: clean manifests helm-check
+	VERSION=${VERSION} bash hack/release/update_versions.sh
+	VERSION=${VERSION} bash hack/release/build_helm.sh
+	VERSION=${VERSION} bash hack/release/setup_release.sh
 
 ###
 # Building

--- a/docs/charts/index.yaml
+++ b/docs/charts/index.yaml
@@ -3,10 +3,10 @@ entries:
   solr-operator:
   - apiVersion: v1
     appVersion: v0.2.5
-    created: "2020-05-14T14:31:51.166349-04:00"
+    created: "2020-05-20T12:28:07.211507-04:00"
     description: The Solr Operator enables easy management of Solr resources within
       Kubernetes.
-    digest: cdc896541390137c0f8aaab7b51f4b944e6cde23f9d8da5ffb0486e20efa5c48
+    digest: 8ccc461fbc1ccd6c149fc34b40f049155f41131c03d291bca1f469cddb0c09dd
     home: https://github.com/bloomberg/solr-operator
     icon: https://lucene.apache.org/theme/images/solr/identity/Solr_Logo_on_white.png
     keywords:
@@ -15,15 +15,14 @@ entries:
     - search
     - lucene
     - operator
-    kubeVersion: '>= 1.13.0'
+    kubeVersion: '>= 1.13.0-0'
     maintainers:
     - email: houston@apache.org
       name: Houston Putman
     name: solr-operator
     sources:
     - https://github.com/bloomberg/solr-operator
-    type: application
     urls:
     - https://github.com/bloomberg/solr-operator/releases/download/v0.2.5/solr-operator-0.2.5.tgz
     version: 0.2.5
-generated: "2020-05-14T14:31:51.161206-04:00"
+generated: "2020-05-20T12:28:07.204853-04:00"

--- a/hack/release/build_helm.sh
+++ b/hack/release/build_helm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+echo "Packaging helm chart for version ${VERSION}"
+
+# Package and Index the helm charts, create release artifacts to upload in GithubRelease
+mkdir -p release-artifacts
+
+rm -rf release-artifacts/*
+
+helm package helm/* --app-version "${VERSION}" --version "${VERSION#v}" -d release-artifacts/
+
+helm repo index release-artifacts/ --url https://github.com/bloomberg/solr-operator/releases/download/${VERSION}/ --merge docs/charts/index.yaml
+
+mv release-artifacts/index.yaml docs/charts/index.yaml

--- a/hack/release/setup_release.sh
+++ b/hack/release/setup_release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+echo "Setting up Release ${VERSION}, making last commit."
+
+# Package and Index the helm charts, create release artifacts to upload in GithubRelease
+cp config/crd/bases/* release-artifacts/.
+
+git add helm config docs
+
+git commit -asm "Cutting release version ${VERSION} of the Solr Operator"

--- a/hack/release/update_versions.sh
+++ b/hack/release/update_versions.sh
@@ -6,7 +6,7 @@ set -o pipefail
 # error on unset variables
 set -u
 
-echo "Setting up Release ${VERSION}"
+echo "Updating the latest version throughout the repo to: ${VERSION}"
 
 # Update default solr-operator version and the helm chart versions.
 gawk -i inplace '$1 == "repository:" { tag = ($2 == "bloomberg/solr-operator") }
@@ -14,21 +14,3 @@ tag && $1 == "tag:"{$1 = "  " $1; $2 = "'"${VERSION}"'"} 1' helm/solr-operator/v
 
 gawk -i inplace '$1 == "version:"{$1 = $1; $2 = "'"${VERSION#v}"'"} 1' helm/solr-operator/Chart.yaml
 gawk -i inplace '$1 == "appVersion:"{$1 = $1; $2 = "'"${VERSION}"'"} 1' helm/solr-operator/Chart.yaml
-
-
-# Package and Index the helm charts, create release artifacts to upload in GithubRelease
-mkdir -p release-artifacts
-
-rm -rf release-artifacts/*
-
-helm package helm/* --app-version "${VERSION}" --version "${VERSION#v}" -d release-artifacts/
-
-helm repo index release-artifacts/ --url https://github.com/bloomberg/solr-operator/releases/download/${VERSION}/ --merge docs/charts/index.yaml
-
-mv release-artifacts/index.yaml docs/charts/index.yaml
-
-cp config/crd/bases/* release-artifacts/.
-
-git add helm config docs
-
-git commit -asm "Cutting release version ${VERSION} of the Solr Operator"

--- a/helm/solr-operator/Chart.yaml
+++ b/helm/solr-operator/Chart.yaml
@@ -4,7 +4,7 @@ name: solr-operator
 description: The Solr Operator enables easy management of Solr resources within Kubernetes.
 version: 0.2.5
 appVersion: v0.2.5
-kubeVersion: ">= 1.13.0"
+kubeVersion: ">= 1.13.0-0"
 home: https://github.com/bloomberg/solr-operator
 sources:
   - https://github.com/bloomberg/solr-operator


### PR DESCRIPTION
This includes hosted kubernetes versions, like EKS and GKE

**Describe your changes**
There is an issue in the Kubernetes versions for EKS and GKE, where they append other information in the version that makes semVer think it is a pre-release. Therefore the following version check fails, because the greater than enforces that a version must be a full release, not a pre-release.

```yaml
kubeVersion: ">= 1.13.0"
```
If we set the compared version to be a pre-release, like `1.13.0-0`, then the `>=` will match pre-release versions as well.

More info can be found here: https://github.com/helm/helm/issues/3810