### PR TITLE
Adding ability to deploy helm chart to a namespace.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ deploy: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: mod-tidy controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=solr-operator-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	kustomize build config/crd > helm/solr-operator/crds/crds.yaml
-	cp config/rbac/role.yaml helm/solr-operator/templates/role.yaml
+	./hack/helm/copy_crds_roles_helm.sh
 
 # Run go fmt against code
 fmt:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,13 +22,17 @@ spec:
         - -etcd-operator=false
         - -ingress-base-domain=ing.local.domain
         image: bloomberg/solr-operator:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: solr-operator
         env:
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         resources:
           limits:
             cpu: 200m

--- a/hack/helm/copy_crds_roles_helm.sh
+++ b/hack/helm/copy_crds_roles_helm.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+echo "Copying CRDs and Role to helm repo"
+
+# Build and package CRDs
+kustomize build config/crd > helm/solr-operator/crds/crds.yaml
+
+# Copy Kube Role for Solr Operator permissions to Helm
+rm helm/solr-operator/templates/role.yaml
+printf '{{- if .Values.rbac.create }}\n{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}\n' > helm/solr-operator/templates/role.yaml
+cat config/rbac/role.yaml >> helm/solr-operator/templates/role.yaml
+printf '\n{{- end }}\n{{- end }}' >> helm/solr-operator/templates/role.yaml
+gawk -i inplace '/^rules:$/{print "  namespace: {{ $namespace }}"}1' helm/solr-operator/templates/role.yaml
+
+# Template the Solr Operator role as needed
+sed -i.bak -E 's/^kind: ClusterRole$/kind: {{ include "solr-operator\.roleType" \$ }}/' helm/solr-operator/templates/role.yaml
+sed -i.bak -E 's/name: solr-operator-role$/name: {{ include "solr-operator\.fullname" \$ }}-role/' helm/solr-operator/templates/role.yaml
+rm helm/solr-operator/templates/role.yaml.bak

--- a/hack/release/update_versions.sh
+++ b/hack/release/update_versions.sh
@@ -14,3 +14,4 @@ tag && $1 == "tag:"{$1 = "  " $1; $2 = "'"${VERSION}"'"} 1' helm/solr-operator/v
 
 gawk -i inplace '$1 == "version:"{$1 = $1; $2 = "'"${VERSION#v}"'"} 1' helm/solr-operator/Chart.yaml
 gawk -i inplace '$1 == "appVersion:"{$1 = $1; $2 = "'"${VERSION}"'"} 1' helm/solr-operator/Chart.yaml
+sed -i.bak -E 's/^\| image.tag \| string \| `".*"` \|/\| image.tag \| string \| `"'${VERSION}'"` \|/g' helm/solr-operator/README.md && rm helm/solr-operator/README.md.bak

--- a/helm/solr-operator/templates/_helpers.tpl
+++ b/helm/solr-operator/templates/_helpers.tpl
@@ -30,3 +30,41 @@ Create chart name and version as used by the chart label.
 {{- define "solr-operator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "solr-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "solr-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ required "Must provide a serviceAccount.name if serviceAccount.create is set to false" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the namespaces to watch (empty if the operator should watch the entire cluster).
+If .Values.watchNamespaces = true, then use the release namespace.
+If .Values.watchNamespaces is a string, use it.
+If .Values.watchNamespaces is empty or false, return empty.
+*/}}
+{{- define "solr-operator.watchNamespaces" -}}
+{{- if .Values.watchNamespaces -}}
+{{- if kindIs "bool" .Values.watchNamespaces -}}
+{{ .Release.Namespace }}
+{{- else -}}
+{{ .Values.watchNamespaces }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine whether to use ClusterRoles or Roles
+*/}}
+{{- define "solr-operator.roleType" -}}
+{{- if .Values.watchNamespaces -}}
+    Role
+{{- else -}}
+    ClusterRole
+{{- end -}}
+{{- end -}}

--- a/helm/solr-operator/templates/deployment.yaml
+++ b/helm/solr-operator/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "solr-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     control-plane: solr-operator
     controller-tools.k8s.io: "1.0"
@@ -20,7 +19,7 @@ spec:
         control-plane: solr-operator
         controller-tools.k8s.io: "1.0"
     spec:
-      serviceAccountName: solr-operator
+      serviceAccountName: {{ include "solr-operator.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}" 
@@ -28,12 +27,24 @@ spec:
         args:
         - -zk-operator={{ .Values.useZkOperator }}
         - -etcd-operator={{ .Values.useEtcdOperator }}
-        - -ingress-base-domain={{ .Values.ingressBaseDomain }}
+        {{- if .Values.ingressBaseDomain }}
+        - --ingress-base-domain={{ .Values.ingressBaseDomain }}
+        {{- end }}
+        {{- if .Values.watchNamespaces }}
+        - --watch-namespaces={{- include "solr-operator.watchNamespaces" . -}}
+        {{- end }}
         env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          {{- if .Values.envVars }}
+          {{- toYaml .Values.envVars | nindent 10 }}
+          {{- end }}
         resources:
-            {{- toYaml .Values.resources | nindent 12 }} 
+          {{- toYaml .Values.resources | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/helm/solr-operator/templates/role.yaml
+++ b/helm/solr-operator/templates/role.yaml
@@ -1,10 +1,13 @@
+{{- if .Values.rbac.create }}
+{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ include "solr-operator.roleType" $ }}
 metadata:
   creationTimestamp: null
-  name: solr-operator-role
+  name: {{ include "solr-operator.fullname" $ }}-role
+  namespace: {{ $namespace }}
 rules:
 - apiGroups:
   - ""
@@ -300,3 +303,6 @@ rules:
   - get
   - patch
   - update
+
+{{- end }}
+{{- end }}

--- a/helm/solr-operator/templates/role_binding.yaml
+++ b/helm/solr-operator/templates/role_binding.yaml
@@ -1,12 +1,18 @@
+{{- if .Values.rbac.create }}
+{{- range $namespace := (split "," (include "solr-operator.watchNamespaces" $)) }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ include "solr-operator.roleType" $ }}Binding
 metadata:
-  name: solr-operator-rolebinding
+  name: {{ include "solr-operator.fullname" $ }}-rolebinding
+  namespace: {{ $namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: solr-operator-role
+  kind: {{ include "solr-operator.roleType" $ }}
+  name: {{ include "solr-operator.fullname" $ }}-role
 subjects:
-- kind: ServiceAccount
-  name: solr-operator
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "solr-operator.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/helm/solr-operator/templates/service_account.yaml
+++ b/helm/solr-operator/templates/service_account.yaml
@@ -1,5 +1,6 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: solr-operator
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "solr-operator.serviceAccountName" . }}
+{{- end }}

--- a/helm/solr-operator/values.yaml
+++ b/helm/solr-operator/values.yaml
@@ -12,10 +12,25 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-
 useZkOperator: "true"
 useEtcdOperator: "false"
 ingressBaseDomain: ""
+
+# A comma-separated list of namespaces that the operator should watch.
+# If empty, the solr operator will watch all namespaces in the cluster.
+watchNamespaces: ""
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # Required if create is false.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
 resources:
   limits:
@@ -24,3 +39,5 @@ resources:
   requests:
     cpu: 100m
     memory: 100Mi
+
+envVars: []


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Resolves #118 Resolves #119*

**Describe your changes**
This PR allows for the solr operator to be deployed to a specific namespace using the helm chart.
This can be done with `helm install --namespace <ex>`.

The ability to watch specific namespaces has also been added via the `watchNamespaces` helm variable, as well as the `--watch-namespaces` option to the solr operator program.
If neither is provided, then the operator will watch the entire kubernetes cluster (all namespaces).

There are also now parameters for creating RBAC/ServiceAccounts.

**Testing performed**
I have installed the operator with many different configurations manually using the helm chart.