### PR TITLE
ZookeeperConnection string now uses all ZK hosts.

### DIFF
--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -518,8 +518,12 @@ func reconcileZk(r *SolrCloudReconciler, request reconcile.Request, instance *so
 				if "" == *external {
 					external = nil
 				}
+				internal := make([]string, zkCluster.Spec.Replicas)
+				for i, _ := range internal {
+					internal[i] = fmt.Sprintf("%s-%d.%s-headless.%s:%d", foundZkCluster.Name, i, foundZkCluster.Name, foundZkCluster.Namespace, foundZkCluster.ZookeeperPorts().Client)
+				}
 				newStatus.ZookeeperConnectionInfo = solr.ZookeeperConnectionInfo{
-					InternalConnectionString: fmt.Sprintf("%s:%d", foundZkCluster.GetClientServiceName(), foundZkCluster.ZookeeperPorts().Client),
+					InternalConnectionString: strings.Join(internal, ","),
 					ExternalConnectionString: external,
 					ChRoot:                   pzk.ChRoot,
 				}

--- a/controllers/solrcloud_controller_test.go
+++ b/controllers/solrcloud_controller_test.go
@@ -344,7 +344,8 @@ func TestCloudWithProvidedZookeeperReconcile(t *testing.T) {
 	g.Eventually(func() error { return testClient.Get(context.TODO(), expectedCloudRequest.NamespacedName, instance) }, timeout).Should(gomega.Succeed())
 
 	// Check that the ZkConnectionInformation is correct
-	assert.Equal(t, instance.ProvidedZookeeperName()+"-client:2181", instance.Status.ZookeeperConnectionInfo.InternalConnectionString, "Wrong zkConnectionString in status")
+	expectedZkConnStr := "foo-clo-solrcloud-zookeeper-0.foo-clo-solrcloud-zookeeper-headless.default:2181,foo-clo-solrcloud-zookeeper-1.foo-clo-solrcloud-zookeeper-headless.default:2181,foo-clo-solrcloud-zookeeper-2.foo-clo-solrcloud-zookeeper-headless.default:2181"
+	assert.Equal(t, expectedZkConnStr, instance.Status.ZookeeperConnectionInfo.InternalConnectionString, "Wrong zkConnectionString in status")
 	assert.Equal(t, "/a-ch/root", instance.Status.ZookeeperConnectionInfo.ChRoot, "Wrong zk chRoot in status")
 	assert.Nil(t, instance.Status.ZookeeperConnectionInfo.ExternalConnectionString, "Since a provided zk is used, the externalConnectionString in the status should be Nil")
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Fixes #129*

Generate a proper ZkConnectionString when using a provided ZK Cluster.

**Testing performed**
Unit tests have been changed to use the expanded zkConnectionString.
