### PR TITLE
Move Chroot creation logic from the operator to a postStart hook

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -843,6 +843,14 @@ func (sc *SolrCloud) ZkConnectionString() string {
 func (scs SolrCloudStatus) ZkConnectionString() string {
 	return scs.ZookeeperConnectionInfo.ZkConnectionString()
 }
+func (scs SolrCloudStatus) DissectZkInfo() (zkConnectionString string, zkServer string, zkChRoot string) {
+	zkConnectionString = scs.ZookeeperConnectionInfo.ZkConnectionString()
+	zkParts := strings.SplitN(zkConnectionString, "/", 2)
+	zkServer = zkParts[0]
+	zkChRoot = "/" + zkParts[1]
+
+	return zkConnectionString, zkServer, zkChRoot
+}
 
 func (zkInfo ZookeeperConnectionInfo) ZkConnectionString() string {
 	return zkInfo.InternalConnectionString + zkInfo.ChRoot

--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sort"
 	"strings"
-	"time"
 )
 
 // SolrCloudReconciler reconciles a SolrCloud object
@@ -226,27 +225,10 @@ func (r *SolrCloudReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		foundStatefulSet := &appsv1.StatefulSet{}
 		err = r.Get(context.TODO(), types.NamespacedName{Name: statefulSet.Name, Namespace: statefulSet.Namespace}, foundStatefulSet)
 		if err != nil && errors.IsNotFound(err) {
-			// Before creating the statefulSet, we must first check that the  ZkConnection String is usable
-			if zkErr := ensureZkChrootExists(r, instance, newStatus.ZookeeperConnectionInfo, &requeueOrNot); zkErr == nil {
-				r.Log.Info("Creating StatefulSet", "namespace", statefulSet.Namespace, "name", statefulSet.Name)
-				err = r.Create(context.TODO(), statefulSet)
-			} else {
-				// Erase the "StatefulSet not found" error, so that we can continue reconciling
-				err = nil
-				r.Log.Info("Cannot create StatefulSet until zkConnectionString & chroot have been ensured to exist.", "namespace", statefulSet.Namespace, "name", statefulSet.Name)
-			}
+			r.Log.Info("Creating StatefulSet", "namespace", statefulSet.Namespace, "name", statefulSet.Name)
+			err = r.Create(context.TODO(), statefulSet)
 		} else if err == nil {
-			updateSS := true
-			// If the statefulSet is using the wrong ZkConnectionString, we must first check that the new ZkConnection String is usable
-			if foundStatefulSet.Annotations[util.SolrZKConnectionStringAnnotation] != statefulSet.Annotations[util.SolrZKConnectionStringAnnotation] {
-				if zkErr := ensureZkChrootExists(r, instance, newStatus.ZookeeperConnectionInfo, &requeueOrNot); zkErr == nil {
-					updateSS = true
-				} else {
-					updateSS = false
-					r.Log.Info("Solr has a new ZkConnectionString, cannot update StatefulSet until new zkConnectionString & chroot have been ensured to exist.", "namespace", statefulSet.Namespace, "name", statefulSet.Name)
-				}
-			}
-			if util.CopyStatefulSetFields(statefulSet, foundStatefulSet) && updateSS {
+			if util.CopyStatefulSetFields(statefulSet, foundStatefulSet) {
 				// Update the found StatefulSet and write the result back if there are any changes
 				r.Log.Info("Updating StatefulSet", "namespace", statefulSet.Namespace, "name", statefulSet.Name)
 				err = r.Update(context.TODO(), foundStatefulSet)
@@ -532,17 +514,6 @@ func reconcileZk(r *SolrCloudReconciler, request reconcile.Request, instance *so
 		}
 	}
 	return nil
-}
-
-func ensureZkChrootExists(r *SolrCloudReconciler, solr *solr.SolrCloud, info solr.ZookeeperConnectionInfo, requeueOrNot *reconcile.Result) error {
-	err := util.CreateChRootIfNecessary(info)
-	if err != nil {
-		r.Log.Error(err, "Zk or Chroot has changed, cannot create new ZK Chroot for Solr Cloud", "namespace", solr.Namespace, "name", solr.Name)
-		requeueOrNot.RequeueAfter = time.Second * 5
-
-		// TODO: Create an event for the SolrCloud so that users understand why the StatefulSet hasn't been updated/created.
-	}
-	return err
 }
 
 func (r *SolrCloudReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/gomega v1.9.0
 	github.com/pravega/zookeeper-operator v0.2.6
-	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200320220750-118fecf932d8
 	k8s.io/api v0.17.0


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Fixes #139*

**Describe your changes**
Currently the Solr Operator takes responsibility of connecting to a ZK instance and ensuring that the given chRoot exists before creating a SolrCloud StatefulSet to connect to that ZKConnectionString. This can be problematic for various reasons, mentioned in #139.

Instead move the logic into a postStart hook. Therefore everytime a Solr pod starts it will use `bin/solr` logic to check to see if the ZK can be connected to and if the chroot exists. If not, it will attempt to create the chroot.

If ZK ACL information have already been loaded into the pod, then these will work with the `bin/solr` commands to connect to ZK and check/create the Chroot.

**Testing performed**
Unit testing added to ensure the correct EnvVars are added and that the postStart hook is only used when a chRoot is specified.

The testing of the postStart hook script was done manually to ensure that the logic works. It has also been tested manually with ZK ACLs.
