### PR TITLE
Use same portName as targetPort in service and fix Status bugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Please visit the following pages for documentation on using and developing the S
 
 ## Version Compatibility & Upgrade Notes
 
+#### v0.2.7
+- The `SolrCloud` and `SolrPrometheusExporter` services' portNames have changed to `"solr-client"` and `"solr-metrics"` from `"ext-solr-client"` and `"ext-solr-metrics"`, respectively.
+This is due to a bug in Kubernetes where `portName` and `targetPort` must match for services.
+
 #### v0.2.6
 - The solr-operator argument `--ingressBaseDomain` has been **DEPRECATED**.
 In order to set the external baseDomain of your clouds, please begin to use `SolrCloud.spec.solrAddressability.external.domainName` instead.

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -945,7 +945,7 @@ func (sc *SolrCloud) InternalNodeUrl(nodeName string, withPort bool) string {
 func (sc *SolrCloud) InternalCommonUrl(withPort bool) (url string) {
 	url = fmt.Sprintf("%s.%s", sc.CommonServiceName(), sc.Namespace) + sc.customKubeDomain()
 	if withPort {
-		url += sc.NodePortSuffix()
+		url += sc.CommonPortSuffix()
 	}
 	return url
 }

--- a/controllers/solrcloud_controller.go
+++ b/controllers/solrcloud_controller.go
@@ -325,8 +325,8 @@ func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, new
 		nodeStatus := solr.SolrNodeStatus{}
 		nodeStatus.Name = p.Name
 		nodeStatus.NodeName = p.Spec.NodeName
-		nodeStatus.InternalAddress = "http://" + solrCloud.InternalNodeUrl(nodeStatus.NodeName, true)
-		if solrCloud.Spec.SolrAddressability.External != nil {
+		nodeStatus.InternalAddress = "http://" + solrCloud.InternalNodeUrl(nodeStatus.Name, true)
+		if solrCloud.Spec.SolrAddressability.External != nil && !solrCloud.Spec.SolrAddressability.External.HideNodes {
 			nodeStatus.ExternalAddress = "http://" + solrCloud.ExternalNodeUrl(nodeStatus.Name, solrCloud.Spec.SolrAddressability.External.DomainName, true)
 		}
 		ready := false
@@ -376,7 +376,7 @@ func reconcileCloudStatus(r *SolrCloudReconciler, solrCloud *solr.SolrCloud, new
 	}
 
 	newStatus.InternalCommonAddress = "http://" + solrCloud.InternalCommonUrl(true)
-	if solrCloud.Spec.SolrAddressability.External != nil {
+	if solrCloud.Spec.SolrAddressability.External != nil && !solrCloud.Spec.SolrAddressability.External.HideCommon {
 		extAddress := "http://" + solrCloud.ExternalCommonUrl(solrCloud.Spec.SolrAddressability.External.DomainName, true)
 		newStatus.ExternalCommonAddress = &extAddress
 	}

--- a/controllers/solrprometheusexporter_controller_test.go
+++ b/controllers/solrprometheusexporter_controller_test.go
@@ -112,6 +112,7 @@ func TestMetricsReconcileWithoutExporterConfig(t *testing.T) {
 
 	service := expectService(t, g, requests, expectedMetricsRequest, metricsSKey, deployment.Spec.Template.Labels)
 	assert.Equal(t, "true", service.Annotations["prometheus.io/scrape"], "Metrics Service Prometheus scraping is not enabled.")
+	assert.EqualValues(t, "solr-metrics", service.Spec.Ports[0].Name, "Wrong port name on common Service")
 }
 
 func TestMetricsReconcileWithExporterConfig(t *testing.T) {
@@ -207,4 +208,5 @@ func TestMetricsReconcileWithExporterConfig(t *testing.T) {
 	assert.Equal(t, "true", service.Annotations["prometheus.io/scrape"], "Metrics Service Prometheus scraping is not enabled.")
 	testMapsEqual(t, "service labels", util.MergeLabelsOrAnnotations(expectedServiceLabels, testMetricsServiceLabels), service.Labels)
 	testMapsEqual(t, "service annotations", util.MergeLabelsOrAnnotations(expectedServiceAnnotations, testMetricsServiceAnnotations), service.Annotations)
+	assert.EqualValues(t, "solr-metrics", service.Spec.Ports[0].Name, "Wrong port name on common Service")
 }

--- a/controllers/util/prometheus_exporter_util.go
+++ b/controllers/util/prometheus_exporter_util.go
@@ -26,10 +26,9 @@ import (
 )
 
 const (
-	SolrMetricsPort        = 8080
-	SolrMetricsPortName    = "solr-metrics"
-	ExtSolrMetricsPort     = 80
-	ExtSolrMetricsPortName = "ext-solr-metrics"
+	SolrMetricsPort     = 8080
+	SolrMetricsPortName = "solr-metrics"
+	ExtSolrMetricsPort  = 80
 
 	DefaultPrometheusExporterEntrypoint = "/opt/solr/contrib/prometheus-exporter/bin/solr-exporter"
 )
@@ -291,7 +290,7 @@ func GenerateSolrMetricsService(solrPrometheusExporter *solr.SolrPrometheusExpor
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: ExtSolrMetricsPortName, Port: ExtSolrMetricsPort, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(SolrMetricsPort)},
+				{Name: SolrMetricsPortName, Port: ExtSolrMetricsPort, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(SolrMetricsPort)},
 			},
 			Selector: selectorLabels,
 		},

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -36,9 +36,8 @@ import (
 )
 
 const (
-	SolrClientPortName    = "solr-client"
-	ExtSolrClientPortName = "ext-solr-client"
-	BackupRestoreVolume   = "backup-restore"
+	SolrClientPortName  = "solr-client"
+	BackupRestoreVolume = "backup-restore"
 
 	SolrZKConnectionStringAnnotation = "solr.apache.org/zkConnectionString"
 
@@ -633,7 +632,7 @@ func GenerateCommonService(solrCloud *solr.SolrCloud) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: ExtSolrClientPortName, Port: int32(solrCloud.Spec.SolrAddressability.CommonServicePort), Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromString(SolrClientPortName)},
+				{Name: SolrClientPortName, Port: int32(solrCloud.Spec.SolrAddressability.CommonServicePort), Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromString(SolrClientPortName)},
 			},
 			Selector: selectorLabels,
 		},
@@ -679,7 +678,7 @@ func GenerateHeadlessService(solrCloud *solr.SolrCloud) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
-				{Name: ExtSolrClientPortName, Port: int32(solrCloud.NodePort()), Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromString(SolrClientPortName)},
+				{Name: SolrClientPortName, Port: int32(solrCloud.NodePort()), Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromString(SolrClientPortName)},
 			},
 			Selector:                 selectorLabels,
 			ClusterIP:                corev1.ClusterIPNone,
@@ -719,7 +718,7 @@ func GenerateNodeService(solrCloud *solr.SolrCloud, nodeName string) *corev1.Ser
 		Spec: corev1.ServiceSpec{
 			Selector: selectorLabels,
 			Ports: []corev1.ServicePort{
-				{Name: ExtSolrClientPortName, Port: int32(solrCloud.NodePort()), Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromString(SolrClientPortName)},
+				{Name: SolrClientPortName, Port: int32(solrCloud.NodePort()), Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromString(SolrClientPortName)},
 			},
 			PublishNotReadyAddresses: true,
 		},


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Fixes #141, #142*

**Describe your changes**
Two issues are fixed here:
1. The portName and targetPort for SolrCloud services have been changed to have the same name. This fixes issues with certain cloud providers that have bugs with regard to that. (#141)
1. The SolrCloud status object had multiple issues with the urls it displayed for users to connect with. (#142)

**Testing performed**
Unit tests have been modified to ensure that these values are now correct in the future.
