### PR TITLE
Adding PriorityClassName in podOptions.

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -95,6 +95,10 @@ type PodOptions struct {
 	// Startup probe parameters
 	// +optional
 	StartupProbe *corev1.Probe `json:"startupProbe,omitempty"`
+
+	// PriorityClassName for the pod
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // ServiceOptions defines custom options for services

--- a/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
+++ b/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
@@ -1653,6 +1653,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    priorityClassName:
+                      description: PriorityClassName for the pod
+                      type: string
                     readinessProbe:
                       description: Readiness probe parameters
                       properties:

--- a/config/crd/bases/solr.bloomberg.com_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.bloomberg.com_solrprometheusexporters.yaml
@@ -686,6 +686,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    priorityClassName:
+                      description: PriorityClassName for the pod
+                      type: string
                     readinessProbe:
                       description: Readiness probe parameters
                       properties:

--- a/controllers/controller_utils_test.go
+++ b/controllers/controller_utils_test.go
@@ -385,7 +385,8 @@ var (
 			Operator: "Exists",
 		},
 	}
-	extraVars = []corev1.EnvVar{
+	testPriorityClass = "p4"
+	extraVars         = []corev1.EnvVar{
 		{
 			Name:  "VAR_1",
 			Value: "VAL_1",

--- a/controllers/solrcloud_controller_test.go
+++ b/controllers/solrcloud_controller_test.go
@@ -167,13 +167,14 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 			SolrGCTune: "gc Options",
 			CustomSolrKubeOptions: solr.CustomSolrKubeOptions{
 				PodOptions: &solr.PodOptions{
-					Annotations:    testPodAnnotations,
-					Labels:         testPodLabels,
-					Tolerations:    testTolerations,
-					NodeSelector:   testNodeSelectors,
-					LivenessProbe:  testProbeLivenessNonDefaults,
-					ReadinessProbe: testProbeReadinessNonDefaults,
-					StartupProbe:   testProbeStartup,
+					Annotations:       testPodAnnotations,
+					Labels:            testPodLabels,
+					Tolerations:       testTolerations,
+					NodeSelector:      testNodeSelectors,
+					LivenessProbe:     testProbeLivenessNonDefaults,
+					ReadinessProbe:    testProbeReadinessNonDefaults,
+					StartupProbe:      testProbeStartup,
+					PriorityClassName: testPriorityClass,
 				},
 				StatefulSetOptions: &solr.StatefulSetOptions{
 					Annotations: testSSAnnotations,
@@ -257,6 +258,7 @@ func TestCustomKubeOptionsCloudReconcile(t *testing.T) {
 	testPodProbe(t, testProbeReadinessNonDefaults, statefulSet.Spec.Template.Spec.Containers[0].ReadinessProbe)
 	assert.ElementsMatch(t, []string{"solr", "stop", "-p", "8983"}, statefulSet.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command, "Incorrect pre-stop command")
 	testPodTolerations(t, testTolerations, statefulSet.Spec.Template.Spec.Tolerations)
+	assert.EqualValues(t, testPriorityClass, statefulSet.Spec.Template.Spec.PriorityClassName, "Incorrect Priority class name for Pod Spec")
 
 	// Check the client Service
 	service := expectService(t, g, requests, expectedCloudRequest, cloudCsKey, statefulSet.Spec.Selector.MatchLabels)

--- a/controllers/solrprometheusexporter_controller_test.go
+++ b/controllers/solrprometheusexporter_controller_test.go
@@ -123,11 +123,12 @@ func TestMetricsReconcileWithExporterConfig(t *testing.T) {
 			Config: testExporterConfig,
 			CustomKubeOptions: solr.CustomExporterKubeOptions{
 				PodOptions: &solr.PodOptions{
-					Annotations:  testPodAnnotations,
-					Labels:       testPodLabels,
-					Volumes:      extraVolumes,
-					Tolerations:  testTolerationsPromExporter,
-					NodeSelector: testNodeSelectors,
+					Annotations:       testPodAnnotations,
+					Labels:            testPodLabels,
+					Volumes:           extraVolumes,
+					Tolerations:       testTolerationsPromExporter,
+					NodeSelector:      testNodeSelectors,
+					PriorityClassName: testPriorityClass,
 				},
 				DeploymentOptions: &solr.DeploymentOptions{
 					Annotations: testDeploymentAnnotations,
@@ -189,6 +190,7 @@ func TestMetricsReconcileWithExporterConfig(t *testing.T) {
 	testMapsEqual(t, "deployment annotations", testDeploymentAnnotations, deployment.Annotations)
 	testMapsEqual(t, "pod labels", util.MergeLabelsOrAnnotations(expectedDeploymentLabels, testPodLabels), deployment.Spec.Template.ObjectMeta.Labels)
 	testMapsEqual(t, "pod annotations", testPodAnnotations, deployment.Spec.Template.ObjectMeta.Annotations)
+	assert.EqualValues(t, testPriorityClass, deployment.Spec.Template.Spec.PriorityClassName, "Incorrect Priority class name for Pod Spec")
 
 	// Test tolerations and node selectors
 	testMapsEqual(t, "pod node selectors", testNodeSelectors, deployment.Spec.Template.Spec.NodeSelector)

--- a/controllers/util/prometheus_exporter_util.go
+++ b/controllers/util/prometheus_exporter_util.go
@@ -224,6 +224,10 @@ func GenerateSolrPrometheusExporterDeployment(solrPrometheusExporter *solr.SolrP
 		if customPodOptions.NodeSelector != nil {
 			deployment.Spec.Template.Spec.NodeSelector = customPodOptions.NodeSelector
 		}
+
+		if customPodOptions.PriorityClassName != "" {
+			deployment.Spec.Template.Spec.PriorityClassName = customPodOptions.PriorityClassName
+		}
 	}
 
 	return deployment

--- a/controllers/util/solr_util.go
+++ b/controllers/util/solr_util.go
@@ -406,6 +406,9 @@ func GenerateStatefulSet(solrCloud *solr.SolrCloud, solrCloudStatus *solr.SolrCl
 			stateful.Spec.Template.Spec.Containers[0].StartupProbe = fillProbe(*customPodOptions.StartupProbe, DefaultStartupProbeInitialDelaySeconds, DefaultStartupProbeTimeoutSeconds, DefaultStartupProbeSuccessThreshold, DefaultStartupProbeFailureThreshold, DefaultStartupProbePeriodSeconds, &defaultHandler)
 		}
 
+		if customPodOptions.PriorityClassName != "" {
+			stateful.Spec.Template.Spec.PriorityClassName = customPodOptions.PriorityClassName
+		}
 	}
 
 	return stateful
@@ -507,6 +510,12 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 		requireUpdate = true
 		log.Info("Update required because:", "Spec.Template.Spec.NodeSelector changed from", to.Spec.Template.Spec.NodeSelector, "To:", from.Spec.Template.Spec.NodeSelector)
 		to.Spec.Template.Spec.NodeSelector = from.Spec.Template.Spec.NodeSelector
+	}
+
+	if !DeepEqualWithNils(to.Spec.Template.Spec.PriorityClassName, from.Spec.Template.Spec.PriorityClassName) {
+		requireUpdate = true
+		log.Info("Update required because:", "Spec.Template.Spec.PriorityClassName changed from", to.Spec.Template.Spec.PriorityClassName, "To:", from.Spec.Template.Spec.PriorityClassName)
+		to.Spec.Template.Spec.PriorityClassName = from.Spec.Template.Spec.PriorityClassName
 	}
 
 	if !DeepEqualWithNils(to.Spec.Template.Spec.Tolerations, from.Spec.Template.Spec.Tolerations) {

--- a/controllers/util/zk_util.go
+++ b/controllers/util/zk_util.go
@@ -299,5 +299,11 @@ func CopyDeploymentFields(from, to *appsv1.Deployment) bool {
 		to.Spec.Template.Spec.NodeSelector = from.Spec.Template.Spec.NodeSelector
 	}
 
+	if !DeepEqualWithNils(to.Spec.Template.Spec.PriorityClassName, from.Spec.Template.Spec.PriorityClassName) {
+		requireUpdate = true
+		log.Info("Update required because:", "Spec.Template.Spec.PriorityClassName changed from", to.Spec.Template.Spec.PriorityClassName, "To:", from.Spec.Template.Spec.PriorityClassName)
+		to.Spec.Template.Spec.PriorityClassName = from.Spec.Template.Spec.PriorityClassName
+	}
+
 	return requireUpdate
 }

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -2780,6 +2780,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    priorityClassName:
+                      description: PriorityClassName for the pod
+                      type: string
                     readinessProbe:
                       description: Readiness probe parameters
                       properties:
@@ -6548,6 +6551,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    priorityClassName:
+                      description: PriorityClassName for the pod
+                      type: string
                     readinessProbe:
                       description: Readiness probe parameters
                       properties:


### PR DESCRIPTION
**Describe your changes**
Add the ability for users to set priorityClassNames for their pods.

**Testing performed**
Custom PriorityClassName tests added to the unit tests for both SolrClouds and SolrPrometheusExporters.
