### PR TITLE
Remove default imagePullPolicy

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -156,15 +156,15 @@ type ContainerImage struct {
 }
 
 func (c *ContainerImage) withDefaults(repo string, version string, policy corev1.PullPolicy) (changed bool) {
-	if c.Repository == "" {
+	if c.Repository == "" && repo != "" {
 		changed = true
 		c.Repository = repo
 	}
-	if c.Tag == "" {
+	if c.Tag == "" && version != "" {
 		changed = true
 		c.Tag = version
 	}
-	if c.PullPolicy == "" {
+	if c.PullPolicy == "" && policy != "" {
 		changed = true
 		c.PullPolicy = policy
 	}

--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	DefaultPullPolicy = corev1.PullIfNotPresent
+	DefaultPullPolicy = "" // This will use the default pullPolicy of Always when the tag is "latest" and IfNotPresent for all other tags.
 
 	DefaultSolrReplicas = int32(3)
 	DefaultSolrRepo     = "library/solr"


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Fixes #136*

**Describe your changes**
The default for new resources managed by the solr operator is to not have an imagePullPolicy specified, allowing the default kubernetes policy to take affect.

**Testing performed**
Tested locally
