### PR TITLE
Use solr.xml from provided ConfigMap

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -132,6 +132,10 @@ type ConfigMapOptions struct {
 	// Labels to be added for the ConfigMap.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// Name of a user provided ConfigMap in the same namespace containing a custom solr.xml
+	// +optional
+	ProvidedConfigMap string `json:"providedConfigMap,omitempty"`
 }
 
 // AdditionalVolume provides information on additional volumes that should be loaded into pods

--- a/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
+++ b/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
@@ -1001,6 +1001,9 @@ spec:
                         type: string
                       description: Labels to be added for the ConfigMap.
                       type: object
+                    providedConfigMap:
+                      description: Name of a user provided ConfigMap in the same namespace containing a custom solr.xml
+                      type: string
                   type: object
                 headlessServiceOptions:
                   description: HeadlessServiceOptions defines the custom options for the headless solrCloud Service.

--- a/config/crd/bases/solr.bloomberg.com_solrprometheusexporters.yaml
+++ b/config/crd/bases/solr.bloomberg.com_solrprometheusexporters.yaml
@@ -62,6 +62,9 @@ spec:
                         type: string
                       description: Labels to be added for the ConfigMap.
                       type: object
+                    providedConfigMap:
+                      description: Name of a user provided ConfigMap in the same namespace containing a custom solr.xml
+                      type: string
                   type: object
                 deploymentOptions:
                   description: DeploymentOptions defines the custom options for the solrPrometheusExporter Deployment.

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,7 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -264,6 +265,7 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -371,6 +373,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/hack/install_dependencies.sh
+++ b/hack/install_dependencies.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 kubebuilder_version=2.3.1
+kustomize_version=3.8.7
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 
@@ -13,7 +14,7 @@ GO111MODULE=on go mod tidy
 
 #Install Kustomize
 if !(which kustomize); then
-  (cd /tmp && curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash)
+  (cd /tmp && curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- ${kustomize_version})
   sudo mv "/tmp/kustomize" /usr/local/bin
   echo "Installed kustomize at /usr/local/bin/kustomize, version: $(kustomize version --short)"
 else

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -2128,6 +2128,9 @@ spec:
                         type: string
                       description: Labels to be added for the ConfigMap.
                       type: object
+                    providedConfigMap:
+                      description: Name of a user provided ConfigMap in the same namespace containing a custom solr.xml
+                      type: string
                   type: object
                 headlessServiceOptions:
                   description: HeadlessServiceOptions defines the custom options for the headless solrCloud Service.
@@ -7028,6 +7031,9 @@ spec:
                         type: string
                       description: Labels to be added for the ConfigMap.
                       type: object
+                    providedConfigMap:
+                      description: Name of a user provided ConfigMap in the same namespace containing a custom solr.xml
+                      type: string
                   type: object
                 deploymentOptions:
                   description: DeploymentOptions defines the custom options for the solrPrometheusExporter Deployment.


### PR DESCRIPTION
Signed-off-by: Timothy Potter <thelabdude@gmail.com>

This fixes https://github.com/bloomberg/solr-operator/issues/86

Introduce a new var `ProvidedConfigMap` in the `CustomSolrKubeOptions.ConfigMapOptions` to allow users to supply the name of a ConfigMap containing a custom `solr.xml`. If supplied, we track the MD5 checksum of the `solr.xml` data in an annotation on the pod spec (`solr.apache.org/solrXmlMd5`) for the StatefulSet to trigger a rolling restart when the `solr.xml` in the `ConfigMap` changes. If supplied on the `SolrCloud` CRD, the controller requires the provided `ConfigMap` to contain a `solr.xml` that **must** have a placeholder for the operator to set the `hostPort` variable, e.g. 
```
<int name="hostPort">${hostPort:80}</int>
```

Includes a unit test that verifies proper reconciliation using a provided ConfigMap and that an update to the `solr.xml` triggers a rolling restart of the StatefulSet (via the annotation changing).

I also tested this manually in Kubernetes by creating my own ConfigMap:
```
---
kind: ConfigMap
apiVersion: v1
metadata:
  name: tjp-custom-solr-xml
data:
  solr.xml: |
    <?xml version="1.0" encoding="UTF-8" ?>
    <solr>
      <solrcloud>
        <str name="host">${host:}</str>
        <int name="hostPort">${hostPort:80}</int>
        <str name="hostContext">${hostContext:solr}</str>
        <bool name="genericCoreNodeNames">${genericCoreNodeNames:true}</bool>
        <int name="zkClientTimeout">${zkClientTimeout:35000}</int>
        <int name="distribUpdateSoTimeout">${distribUpdateSoTimeout:600000}</int>
        <int name="distribUpdateConnTimeout">${distribUpdateConnTimeout:60000}</int>
        <str name="zkCredentialsProvider">${zkCredentialsProvider:org.apache.solr.common.cloud.DefaultZkCredentialsProvider}</str>
        <str name="zkACLProvider">${zkACLProvider:org.apache.solr.common.cloud.DefaultZkACLProvider}</str>
      </solrcloud>
      <shardHandlerFactory name="shardHandlerFactory" class="HttpShardHandlerFactory">
        <int name="socketTimeout">${socketTimeout:600000}</int>
        <int name="connTimeout">${connTimeout:60000}</int>
      </shardHandlerFactory>
    </solr>
```

And then referencing it in the SolrCloud definition:
```
  customSolrKubeOptions:
    configMapOptions:
      providedConfigMap: tjp-custom-solr-xml
```
