### PR TITLE
Fixing upgrade issue with new Status fields.

### DIFF
--- a/api/v1beta1/solrcloud_types.go
+++ b/api/v1beta1/solrcloud_types.go
@@ -837,6 +837,7 @@ type SolrCloudStatus struct {
 	ReadyReplicas int32 `json:"readyReplicas"`
 
 	// UpToDateNodes is the number of number of Solr Node pods that are running the latest pod spec
+	// +optional
 	UpToDateNodes int32 `json:"upToDateNodes"`
 
 	// The version of solr that the cloud is running
@@ -887,6 +888,7 @@ type SolrNodeStatus struct {
 	Version string `json:"version"`
 
 	// This Solr Node pod is using the latest version of solrcloud pod spec.
+	// +optional
 	SpecUpToDate bool `json:"specUpToDate"`
 }
 

--- a/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
+++ b/config/crd/bases/solr.bloomberg.com_solrclouds.yaml
@@ -7092,7 +7092,6 @@ spec:
                   - name
                   - nodeName
                   - ready
-                  - specUpToDate
                   - version
                   type: object
                 type: array
@@ -7159,7 +7158,6 @@ spec:
             - readyReplicas
             - replicas
             - solrNodes
-            - upToDateNodes
             - version
             - zookeeperConnectionInfo
             type: object

--- a/helm/solr-operator/crds/crds.yaml
+++ b/helm/solr-operator/crds/crds.yaml
@@ -8218,7 +8218,6 @@ spec:
                   - name
                   - nodeName
                   - ready
-                  - specUpToDate
                   - version
                   type: object
                 type: array
@@ -8285,7 +8284,6 @@ spec:
             - readyReplicas
             - replicas
             - solrNodes
-            - upToDateNodes
             - version
             - zookeeperConnectionInfo
             type: object


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #169*

**Describe your changes**
Made the two new Status fields in v0.2.7 optional:
- Status.upToDateNodes
- Status.nodes.specUpToDate

**Testing performed**
Manually tested with upgrading the CRDs to v0.2.7 (with this fix), then upgrading the operator to v0.2.7
